### PR TITLE
Simplify "add_foo" to "add" and allow to add multiple arguments by one function.

### DIFF
--- a/examples/encdec/encdec.cc
+++ b/examples/encdec/encdec.cc
@@ -32,7 +32,7 @@
 #include <random>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 #include "lstm.h"
 #include "utils.h"
@@ -65,12 +65,12 @@ class EncoderDecoder : public Model {
 
 public:
   EncoderDecoder() : dropout_rate_(DROPOUT_RATE) {
-    add_parameter("src_lookup", psrc_lookup_);
-    add_parameter("trg_lookup", ptrg_lookup_);
-    add_parameter("why", pwhy_);
-    add_parameter("by", pby_);
-    add_submodel("src_lstm", src_lstm_);
-    add_submodel("trg_lstm", trg_lstm_);
+    add("src_lookup", psrc_lookup_);
+    add("trg_lookup", ptrg_lookup_);
+    add("why", pwhy_);
+    add("by", pby_);
+    add("src_lstm", src_lstm_);
+    add("trg_lstm", trg_lstm_);
   }
 
   // Initializes the model.
@@ -130,7 +130,7 @@ void train(
     ::EncoderDecoder<Node> &encdec, Optimizer &optimizer,
     const string &prefix, float best_valid_ppl) {
   // Registers all parameters to the optimizer.
-  optimizer.add_model(encdec);
+  optimizer.add(encdec);
 
   // Loads vocab.
   const auto src_vocab = ::make_vocab(SRC_TRAIN_FILE, SRC_VOCAB_SIZE);
@@ -281,8 +281,7 @@ int main(const int argc, const char *argv[]) {
   }
 
   cerr << "initializing device ... " << flush;
-  //devices::Naive dev;
-  devices::CUDA dev(0);
+  devices::Naive dev;  // devices::CUDA dev(0);
   Device::set_default(dev);
   cerr << "done." << endl;
 

--- a/examples/encdec/encdec_attention.cc
+++ b/examples/encdec/encdec_attention.cc
@@ -36,7 +36,7 @@
 #include <random>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 #include "lstm.h"
 #include "utils.h"
@@ -69,15 +69,15 @@ class AttentionalEncoderDecoder : public Model {
 
 public:
   AttentionalEncoderDecoder() : dropout_rate_(DROPOUT_RATE) {
-    add_parameter("src_lookup", psrc_lookup_);
-    add_parameter("trg_lookup", ptrg_lookup_);
-    add_parameter("whj", pwhj_);
-    add_parameter("bj", pbj_);
-    add_parameter("wjy", pwjy_);
-    add_parameter("by", pby_);
-    add_submodel("src_fw_lstm", src_fw_lstm_);
-    add_submodel("src_bw_lstm", src_bw_lstm_);
-    add_submodel("trg_lstm", trg_lstm_);
+    add("src_lookup", psrc_lookup_);
+    add("trg_lookup", ptrg_lookup_);
+    add("whj", pwhj_);
+    add("bj", pbj_);
+    add("wjy", pwjy_);
+    add("by", pby_);
+    add("src_fw_lstm", src_fw_lstm_);
+    add("src_bw_lstm", src_bw_lstm_);
+    add("trg_lstm", trg_lstm_);
   }
 
   void init(
@@ -172,7 +172,7 @@ void train(
     ::AttentionalEncoderDecoder<Node> &encdec, Optimizer &optimizer,
     const string &prefix, float best_valid_ppl) {
   // Registers all parameters to the optimizer.
-  optimizer.add_model(encdec);
+  optimizer.add(encdec);
 
   // Loads vocab.
   const auto src_vocab = ::make_vocab(SRC_TRAIN_FILE, SRC_VOCAB_SIZE);
@@ -328,8 +328,7 @@ int main(const int argc, const char *argv[]) {
   }
 
   cerr << "initializing device ... " << flush;
-  //devices::Naive dev;
-  devices::CUDA dev(0);
+  devices::Naive dev;  // devices::CUDA dev(0);
   Device::set_default(dev);
   cerr << "done." << endl;
 

--- a/examples/encdec/lstm.h
+++ b/examples/encdec/lstm.h
@@ -20,9 +20,9 @@ class LSTM : public primitiv::Model {
 
 public:
   LSTM() {
-    add_parameter("wxh", pwxh_);
-    add_parameter("whh", pwhh_);
-    add_parameter("bh", pbh_);
+    add("wxh", pwxh_);
+    add("whh", pwhh_);
+    add("bh", pbh_);
   }
 
   // Initializes the model.

--- a/examples/encdec/utils.h
+++ b/examples/encdec/utils.h
@@ -88,7 +88,6 @@ inline std::vector<unsigned> line_to_sent(
 inline std::vector<std::vector<unsigned>> load_corpus(
     const std::string &path,
     const std::unordered_map<std::string, unsigned> &vocab) {
-  const unsigned unk_id = vocab.at("<unk>");
   std::ifstream ifs;
   ::open_file(path, ifs);
   std::vector<std::vector<unsigned>> corpus;

--- a/examples/mnist/mnist.cc
+++ b/examples/mnist/mnist.cc
@@ -19,7 +19,7 @@
 #include <vector>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 using namespace primitiv;
 using namespace std;
@@ -74,13 +74,16 @@ vector<char> load_labels(const string &filename, const unsigned n) {
 
 int main() {
   // Loads data
-  vector<float> train_inputs = ::load_images("data/train-images-idx3-ubyte", NUM_TRAIN_SAMPLES);
-  vector<char> train_labels = ::load_labels("data/train-labels-idx1-ubyte", NUM_TRAIN_SAMPLES);
-  vector<float> test_inputs = ::load_images("data/t10k-images-idx3-ubyte", NUM_TEST_SAMPLES);
-  vector<char> test_labels = ::load_labels("data/t10k-labels-idx1-ubyte", NUM_TEST_SAMPLES);
+  vector<float> train_inputs
+    = ::load_images("data/train-images-idx3-ubyte", NUM_TRAIN_SAMPLES);
+  vector<char> train_labels
+    = ::load_labels("data/train-labels-idx1-ubyte", NUM_TRAIN_SAMPLES);
+  vector<float> test_inputs
+    = ::load_images("data/t10k-images-idx3-ubyte", NUM_TEST_SAMPLES);
+  vector<char> test_labels
+    = ::load_labels("data/t10k-labels-idx1-ubyte", NUM_TEST_SAMPLES);
 
-  // Uses GPU.
-  devices::CUDA dev(0);
+  devices::Naive dev;  //devices::CUDA dev(0);
   Device::set_default(dev);
   Graph g;
   Graph::set_default(g);
@@ -93,10 +96,7 @@ int main() {
 
   // Optimizer
   O::SGD optimizer(.5);
-  optimizer.add_parameter(pw1);
-  optimizer.add_parameter(pb1);
-  optimizer.add_parameter(pw2);
-  optimizer.add_parameter(pb2);
+  optimizer.add(pw1, pb1, pw2, pb2);
 
   // Helper lambda to construct the predictor network.
   auto make_graph = [&](const vector<float> &inputs, bool train) {
@@ -169,10 +169,10 @@ int main() {
       vector<float> y_val = y.to_vector();
       for (unsigned i = 0; i < BATCH_SIZE; ++i) {
         float maxval = -1e10;
-        unsigned argmax = -1;
+        int argmax = -1;
         for (unsigned j = 0; j < NUM_OUTPUT_UNITS; ++j) {
           float v = y_val[j + i * NUM_OUTPUT_UNITS];
-          if (v > maxval) maxval = v, argmax = j;
+          if (v > maxval) maxval = v, argmax = static_cast<int>(j);
         }
         if (argmax == test_labels[i + batch * BATCH_SIZE]) ++match;
       }

--- a/examples/mnist/mnist_multi_gpu.cc
+++ b/examples/mnist/mnist_multi_gpu.cc
@@ -76,10 +76,14 @@ vector<char> load_labels(const string &filename, const unsigned n) {
 
 int main() {
   // Loads data
-  vector<float> train_inputs = ::load_images("data/train-images-idx3-ubyte", NUM_TRAIN_SAMPLES);
-  vector<char> train_labels = ::load_labels("data/train-labels-idx1-ubyte", NUM_TRAIN_SAMPLES);
-  vector<float> test_inputs = ::load_images("data/t10k-images-idx3-ubyte", NUM_TEST_SAMPLES);
-  vector<char> test_labels = ::load_labels("data/t10k-labels-idx1-ubyte", NUM_TEST_SAMPLES);
+  vector<float> train_inputs
+    = ::load_images("data/train-images-idx3-ubyte", NUM_TRAIN_SAMPLES);
+  vector<char> train_labels
+    = ::load_labels("data/train-labels-idx1-ubyte", NUM_TRAIN_SAMPLES);
+  vector<float> test_inputs
+    = ::load_images("data/t10k-images-idx3-ubyte", NUM_TEST_SAMPLES);
+  vector<char> test_labels
+    = ::load_labels("data/t10k-labels-idx1-ubyte", NUM_TEST_SAMPLES);
 
   // Initializes 2 device objects which manage different GPUs.
   devices::CUDA dev0(0);  // GPU 0
@@ -175,10 +179,10 @@ int main() {
       vector<float> y_val = y.to_vector();
       for (unsigned i = 0; i < BATCH_SIZE; ++i) {
         float maxval = -1e10;
-        unsigned argmax = -1;
+        int argmax = -1;
         for (unsigned j = 0; j < NUM_OUTPUT_UNITS; ++j) {
           float v = y_val[j + i * NUM_OUTPUT_UNITS];
-          if (v > maxval) maxval = v, argmax = j;
+          if (v > maxval) maxval = v, argmax = static_cast<int>(j);
         }
         if (argmax == test_labels[i + batch * BATCH_SIZE]) ++match;
       }

--- a/examples/ptb/ptb_rnnlm.cc
+++ b/examples/ptb/ptb_rnnlm.cc
@@ -25,7 +25,7 @@
 #include <vector>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 #include "utils.h"
 
@@ -43,14 +43,13 @@ static const unsigned MAX_EPOCH = 100;
 
 class RNNLM : public Model {
 public:
-  RNNLM(unsigned vocab_size, unsigned eos_id)
-    : eos_id_(eos_id)
-    , pwlookup_({NUM_HIDDEN_UNITS, vocab_size}, XavierUniform())
+  RNNLM(unsigned vocab_size)
+    : pwlookup_({NUM_HIDDEN_UNITS, vocab_size}, XavierUniform())
     , pwxs_({NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS}, XavierUniform())
     , pwsy_({vocab_size, NUM_HIDDEN_UNITS}, XavierUniform()) {
-      add_parameter("pwlookup", pwlookup_);
-      add_parameter("pwxs", pwxs_);
-      add_parameter("pwsy", pwsy_);
+      add("pwlookup", pwlookup_);
+      add("pwxs", pwxs_);
+      add("pwsy", pwsy_);
     }
 
   // Forward function of RNNLM. Input data should be arranged below:
@@ -88,7 +87,6 @@ public:
   }
 
 private:
-  unsigned eos_id_;
   Parameter pwlookup_;
   Parameter pwxs_;
   Parameter pwsy_;
@@ -114,20 +112,19 @@ int main() {
   cout << "valid: " << num_valid_sents << " sentences, "
                     << num_valid_labels << " labels" << endl;
 
-  // Uses GPU.
-  devices::CUDA dev(0);
+  devices::Naive dev;  //devices::CUDA dev(0);
   Device::set_default(dev);
   Graph g;
   Graph::set_default(g);
 
   // Our LM.
-  ::RNNLM lm(vocab.size(), eos_id);
+  ::RNNLM lm(vocab.size());
 
   // Optimizer.
   Adam optimizer;
   optimizer.set_weight_decay(1e-6);
   optimizer.set_gradient_clipping(5);
-  optimizer.add_model(lm);
+  optimizer.add(lm);
 
   // Batch randomizer.
   random_device rd;

--- a/examples/ptb/ptb_rnnlm_sru.cc
+++ b/examples/ptb/ptb_rnnlm_sru.cc
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 #include "utils.h"
 
@@ -51,8 +51,8 @@ public:
   Affine(unsigned in_size, unsigned out_size)
     : pw_({out_size, in_size}, Uniform(-0.1, 0.1))
     , pb_({out_size}, Constant(0)) {
-      add_parameter("pw", pw_);
-      add_parameter("pb", pb_);
+      add("pw", pw_);
+      add("pb", pb_);
     }
 
   // Initializes internal values.
@@ -86,9 +86,9 @@ public:
     , pw_({3 * out_size, in_size}, Uniform(-0.1, 0.1))
     , pbf_({out_size}, Constant(0))
     , pbr_({out_size}, Constant(0)) {
-      add_parameter("pw", pw_);
-      add_parameter("pbf", pbf_);
-      add_parameter("pbr", pbr_);
+      add("pw", pw_);
+      add("pbf", pbf_);
+      add("pbr", pbr_);
     }
 
   // Initializes internal values.
@@ -125,22 +125,20 @@ public:
 // Language model using above SRU.
 template <typename Var>
 class RNNLM : public Model {
-  unsigned eos_id_;
   Parameter plookup_;
   SRU<Var> rnn1_, rnn2_;
   Affine<Var> hy_;
 
 public:
-  RNNLM(unsigned vocab_size, unsigned eos_id)
-    : eos_id_(eos_id)
-    , plookup_({NUM_HIDDEN_UNITS, vocab_size}, Uniform(-0.1, 0.1))
+  RNNLM(unsigned vocab_size)
+    : plookup_({NUM_HIDDEN_UNITS, vocab_size}, Uniform(-0.1, 0.1))
     , rnn1_(NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS)
     , rnn2_(NUM_HIDDEN_UNITS, NUM_HIDDEN_UNITS)
     , hy_(NUM_HIDDEN_UNITS, vocab_size) {
-      add_parameter("plookup", plookup_);
-      add_submodel("rnn1", rnn1_);
-      add_submodel("rnn2", rnn2_);
-      add_submodel("hy", hy_);
+      add("plookup", plookup_);
+      add("rnn1", rnn1_);
+      add("rnn2", rnn2_);
+      add("hy", hy_);
     }
 
   // Forward function of RNNLM. Input data should be arranged below:
@@ -150,9 +148,7 @@ public:
   //   ...,
   //   {sent1_wordM, sent2_wordM, ..., sentN_wordM},  // last output (<eos>)
   // };
-  vector<Var> forward(
-      const vector<vector<unsigned>> &inputs, bool train) {
-    const unsigned batch_size = inputs[0].size();
+  vector<Var> forward(const vector<vector<unsigned>> &inputs, bool train) {
     Var lookup = F::parameter<Var>(plookup_);
     rnn1_.init();
     rnn2_.init();
@@ -208,20 +204,19 @@ int main() {
   cout << "valid: " << num_valid_sents << " sentences, "
                     << num_valid_labels << " labels" << endl;
 
-  // Uses GPU.
-  devices::CUDA dev(0);
+  devices::Naive dev;  // devices::CUDA dev(0);
   Device::set_default(dev);
   Graph g;
   Graph::set_default(g);
 
   // Our LM.
-  ::RNNLM<Node> lm(vocab.size(), eos_id);
+  ::RNNLM<Node> lm(vocab.size());
 
   // Optimizer.
   SGD optimizer(1);
   //optimizer.set_weight_decay(1e-6);
   optimizer.set_gradient_clipping(5);
-  optimizer.add_model(lm);
+  optimizer.add(lm);
 
   // Batch randomizer.
   random_device rd;

--- a/examples/xor/xor.cc
+++ b/examples/xor/xor.cc
@@ -47,10 +47,7 @@ int main() {
 
   // Optimizer
   O::SGD optimizer(0.1);
-  optimizer.add_parameter(pw1);
-  optimizer.add_parameter(pb1);
-  optimizer.add_parameter(pw2);
-  optimizer.add_parameter(pb2);
+  optimizer.add(pw1, pb1, pw2, pb2);
 
   // Fixed input data
   const vector<float> input_data {

--- a/primitiv/model.cc
+++ b/primitiv/model.cc
@@ -68,7 +68,7 @@ void Model::save(const std::string &path, bool with_stats) const {
   }
 }
 
-void Model::add_parameter(const std::string &name, Parameter &param) {
+void Model::add(const std::string &name, Parameter &param) {
   if (name_set_.find(name) != name_set_.end()) {
     THROW_ERROR(
         "Name '" << name << "' already exists in the model.");
@@ -82,7 +82,7 @@ void Model::add_parameter(const std::string &name, Parameter &param) {
   param_kv_.emplace(name, &param);
 }
 
-void Model::add_submodel(const std::string &name, Model &model) {
+void Model::add(const std::string &name, Model &model) {
   if (&model == this) {
     THROW_ERROR("Can't add self as a submodel.");
   }

--- a/primitiv/model.h
+++ b/primitiv/model.h
@@ -48,7 +48,7 @@ public:
    * @remarks `name` should not be overlapped with all registered parameters and
    *          submodels.
    */
-  void add_parameter(const std::string &name, Parameter &param);
+  void add(const std::string &name, Parameter &param);
 
   /**
    * Registers a new submodel.
@@ -57,7 +57,7 @@ public:
    * @remarks `name` should not be overlapped with all registered parameters and
    *          submodels.
    */
-  void add_submodel(const std::string &name, Model &model);
+  void add(const std::string &name, Model &model);
 
   /**
    * Retrieves a parameter with specified name.

--- a/primitiv/optimizer.cc
+++ b/primitiv/optimizer.cc
@@ -51,7 +51,7 @@ void Optimizer::save(const std::string &path) const {
   writer << uint_configs << float_configs;
 }
 
-void Optimizer::add_parameter(Parameter &param) {
+void Optimizer::add_inner(Parameter &param) {
   if (params_.find(&param) != params_.end()) {
     THROW_ERROR("Parameter '" << &param << "' is already registered.");
   }
@@ -59,9 +59,9 @@ void Optimizer::add_parameter(Parameter &param) {
   configure_parameter(param);
 }
 
-void Optimizer::add_model(const Model &model) {
+void Optimizer::add_inner(const Model &model) {
   for (const auto &kv : model.get_trainable_parameters()) {
-    add_parameter(*kv.second);
+    add_inner(*kv.second);
   }
 }
 

--- a/primitiv/optimizer.h
+++ b/primitiv/optimizer.h
@@ -97,17 +97,45 @@ public:
   }
 
   /**
-   * Registers a parameter.
-   * @param param Parameter to be optimized.
+   * Registers multiple parameters and models.
+   * This function is defined as the sentinel of other specialized functions.
+   * @param args List of arguments (could be empty).
    */
-  void add_parameter(Parameter &param);
+  void add() { /* do nothing */ }
 
   /**
-   * Registers all trainable parameters in a model.
+   * Registers multiple parameters and models.
+   * @param model_or_param Parameter or Model to be optimized.
+   * @param args List of remaining Parameter or Model to be optimized.
+   *
+   * This function behaves similar to multiple `add()` calls with the same
+   * order of arguments.
+   * E.g., below lines should behave similarly (except the case of exceptions):
+   *
+   *     add(a, b, c, d);
+   *     add(a, b); add(c, d);
+   *     add(a); add(b); add(c); add(d);
+   */
+  template<typename T, typename... Args>
+  void add(T &model_or_param, Args &... args) {
+    add_inner(model_or_param);
+    add(args...);
+  }
+
+private:
+  /**
+   * Registers a parameter (inner function).
+   * @param param Parameter to be optimized.
+   */
+  void add_inner(Parameter &param);
+
+  /**
+   * Registers all trainable parameters in a model (inner function).
    * @param model Model to be optimized.
    */
-  void add_model(const Model &model);
+  void add_inner(const Model &model);
 
+public:
   /**
    * Resets all gradients of registered parameters.
    */

--- a/test/model_test.cc
+++ b/test/model_test.cc
@@ -30,72 +30,72 @@ TEST_F(ModelTest, CheckAddParameter) {
   Model m;
   Parameter p1, p2, p3;
 
-  EXPECT_NO_THROW(m.add_parameter("p1", p1));
-  EXPECT_THROW(m.add_parameter("p1", p1), Error);
-  EXPECT_THROW(m.add_parameter("x", p1), Error);
+  EXPECT_NO_THROW(m.add("p1", p1));
+  EXPECT_THROW(m.add("p1", p1), Error);
+  EXPECT_THROW(m.add("x", p1), Error);
 
-  EXPECT_THROW(m.add_parameter("p1", p2), Error);
-  EXPECT_NO_THROW(m.add_parameter("p2", p2));
-  EXPECT_THROW(m.add_parameter("p2", p2), Error);
-  EXPECT_THROW(m.add_parameter("x", p2), Error);
+  EXPECT_THROW(m.add("p1", p2), Error);
+  EXPECT_NO_THROW(m.add("p2", p2));
+  EXPECT_THROW(m.add("p2", p2), Error);
+  EXPECT_THROW(m.add("x", p2), Error);
 
-  EXPECT_THROW(m.add_parameter("p1", p3), Error);
-  EXPECT_THROW(m.add_parameter("p2", p3), Error);
-  EXPECT_NO_THROW(m.add_parameter("p3", p3));
-  EXPECT_THROW(m.add_parameter("p3", p3), Error);
-  EXPECT_THROW(m.add_parameter("x", p3), Error);
+  EXPECT_THROW(m.add("p1", p3), Error);
+  EXPECT_THROW(m.add("p2", p3), Error);
+  EXPECT_NO_THROW(m.add("p3", p3));
+  EXPECT_THROW(m.add("p3", p3), Error);
+  EXPECT_THROW(m.add("x", p3), Error);
 }
 
 TEST_F(ModelTest, CheckAddSubmodel) {
   Model m, sm1, sm2;
   Parameter p1, p2;
 
-  EXPECT_NO_THROW(m.add_parameter("p1", p1));
-  EXPECT_NO_THROW(m.add_submodel("sm1", sm1));
-  EXPECT_THROW(m.add_submodel("sm1", sm1), Error);
-  EXPECT_THROW(m.add_submodel("x", sm1), Error);
+  EXPECT_NO_THROW(m.add("p1", p1));
+  EXPECT_NO_THROW(m.add("sm1", sm1));
+  EXPECT_THROW(m.add("sm1", sm1), Error);
+  EXPECT_THROW(m.add("x", sm1), Error);
 
-  EXPECT_THROW(m.add_parameter("p1", p2), Error);
-  EXPECT_THROW(m.add_parameter("sm1", p2), Error);
-  EXPECT_THROW(m.add_submodel("p1", sm2), Error);
-  EXPECT_THROW(m.add_submodel("sm1", sm2), Error);
+  EXPECT_THROW(m.add("p1", p2), Error);
+  EXPECT_THROW(m.add("sm1", p2), Error);
+  EXPECT_THROW(m.add("p1", sm2), Error);
+  EXPECT_THROW(m.add("sm1", sm2), Error);
 
-  EXPECT_NO_THROW(m.add_parameter("p2", p2));
-  EXPECT_NO_THROW(m.add_submodel("sm2", sm2));
-  EXPECT_THROW(m.add_submodel("sm2", sm2), Error);
-  EXPECT_THROW(m.add_submodel("x", sm2), Error);
+  EXPECT_NO_THROW(m.add("p2", p2));
+  EXPECT_NO_THROW(m.add("sm2", sm2));
+  EXPECT_THROW(m.add("sm2", sm2), Error);
+  EXPECT_THROW(m.add("x", sm2), Error);
 }
 
 TEST_F(ModelTest, CheckAddSubmodelCycle) {
   Model m1, m2, m3, m4;
 
-  EXPECT_THROW(m1.add_submodel("self", m1), Error);
+  EXPECT_THROW(m1.add("self", m1), Error);
 
-  EXPECT_NO_THROW(m1.add_submodel("m2", m2));
-  EXPECT_THROW(m2.add_submodel("m1", m1), Error);
+  EXPECT_NO_THROW(m1.add("m2", m2));
+  EXPECT_THROW(m2.add("m1", m1), Error);
 
-  EXPECT_NO_THROW(m2.add_submodel("m3", m3));
-  EXPECT_THROW(m3.add_submodel("m1", m1), Error);
-  EXPECT_THROW(m3.add_submodel("m2", m2), Error);
+  EXPECT_NO_THROW(m2.add("m3", m3));
+  EXPECT_THROW(m3.add("m1", m1), Error);
+  EXPECT_THROW(m3.add("m2", m2), Error);
 
-  EXPECT_NO_THROW(m2.add_submodel("m4", m4));
-  EXPECT_THROW(m4.add_submodel("m1", m1), Error);
-  EXPECT_THROW(m4.add_submodel("m2", m2), Error);
+  EXPECT_NO_THROW(m2.add("m4", m4));
+  EXPECT_THROW(m4.add("m1", m1), Error);
+  EXPECT_THROW(m4.add("m2", m2), Error);
 
   // NOTE(odashi):
   // This generates a diamond hierarchy.
   // We allow to do this for now, but Trainer.add_model() may fail because of
   // registering same parameters multiple times.
-  EXPECT_NO_THROW(m4.add_submodel("m3", m3));
+  EXPECT_NO_THROW(m4.add("m3", m3));
 }
 
 TEST_F(ModelTest, CheckGetParameter) {
   Model m, sm;
   Parameter p1, p2, p3;
-  m.add_parameter("p1", p1);
-  m.add_parameter("p2", p2);
-  sm.add_parameter("p3", p3);
-  m.add_submodel("sm", sm);
+  m.add("p1", p1);
+  m.add("p2", p2);
+  sm.add("p3", p3);
+  m.add("sm", sm);
 
   EXPECT_EQ(&p1, &m.get_parameter("p1"));
   EXPECT_EQ(&p2, &m.get_parameter("p2"));
@@ -114,10 +114,10 @@ TEST_F(ModelTest, CheckGetParameter) {
 TEST_F(ModelTest, CheckGetParameterRecursiveByInitializerList) {
   Model m, sm;
   Parameter p1, p2, p3;
-  m.add_parameter("p1", p1);
-  sm.add_parameter("p2", p2);
-  sm.add_parameter("p3", p3);
-  m.add_submodel("sm", sm);
+  m.add("p1", p1);
+  sm.add("p2", p2);
+  sm.add("p3", p3);
+  m.add("sm", sm);
 
   EXPECT_EQ(&p1, &m.get_parameter({"p1"}));
   EXPECT_EQ(&p2, &m.get_parameter({"sm", "p2"}));
@@ -148,10 +148,10 @@ TEST_F(ModelTest, CheckGetParameterRecursiveByInitializerList) {
 TEST_F(ModelTest, CheckGetParameterRecursiveByVector) {
   Model m, sm;
   Parameter p1, p2, p3;
-  m.add_parameter("p1", p1);
-  sm.add_parameter("p2", p2);
-  sm.add_parameter("p3", p3);
-  m.add_submodel("sm", sm);
+  m.add("p1", p1);
+  sm.add("p2", p2);
+  sm.add("p3", p3);
+  m.add("sm", sm);
 
   EXPECT_EQ(&p1, &m.get_parameter(vector<string> {"p1"}));
   EXPECT_EQ(&p2, &m.get_parameter(vector<string> {"sm", "p2"}));
@@ -182,10 +182,10 @@ TEST_F(ModelTest, CheckGetParameterRecursiveByVector) {
 TEST_F(ModelTest, CheckGetSubmodel) {
   Model m, sm1, sm2, ssm;
   Parameter p;
-  m.add_parameter("p", p);
-  m.add_submodel("sm1", sm1);
-  m.add_submodel("sm2", sm2);
-  sm1.add_submodel("ssm", ssm);
+  m.add("p", p);
+  m.add("sm1", sm1);
+  m.add("sm2", sm2);
+  sm1.add("ssm", ssm);
 
   EXPECT_EQ(&sm1, &m.get_submodel("sm1"));
   EXPECT_EQ(&sm2, &m.get_submodel("sm2"));
@@ -202,10 +202,10 @@ TEST_F(ModelTest, CheckGetSubmodel) {
 TEST_F(ModelTest, CheckGetSubmodelRecursiveByInitializerList) {
   Model m, sm1, sm2, ssm;
   Parameter p;
-  m.add_parameter("p", p);
-  m.add_submodel("sm1", sm1);
-  m.add_submodel("sm2", sm2);
-  sm1.add_submodel("ssm", ssm);
+  m.add("p", p);
+  m.add("sm1", sm1);
+  m.add("sm2", sm2);
+  sm1.add("ssm", ssm);
 
   EXPECT_EQ(&sm1, &m.get_submodel({"sm1"}));
   EXPECT_EQ(&sm2, &m.get_submodel({"sm2"}));
@@ -230,10 +230,10 @@ TEST_F(ModelTest, CheckGetSubmodelRecursiveByInitializerList) {
 TEST_F(ModelTest, CheckGetSubmodelRecursiveByVector) {
   Model m, sm1, sm2, ssm;
   Parameter p;
-  m.add_parameter("p", p);
-  m.add_submodel("sm1", sm1);
-  m.add_submodel("sm2", sm2);
-  sm1.add_submodel("ssm", ssm);
+  m.add("p", p);
+  m.add("sm1", sm1);
+  m.add("sm2", sm2);
+  sm1.add("ssm", ssm);
 
   EXPECT_EQ(&sm1, &m.get_submodel(vector<string> {"sm1"}));
   EXPECT_EQ(&sm2, &m.get_submodel(vector<string> {"sm2"}));
@@ -258,9 +258,9 @@ TEST_F(ModelTest, CheckGetSubmodelRecursiveByVector) {
 TEST_F(ModelTest, CheckGetAllParameters) {
   Model m;
   Parameter p1, p2, p3;
-  m.add_parameter("p1", p1);
-  m.add_parameter("p2", p2);
-  m.add_parameter("p3", p3);
+  m.add("p1", p1);
+  m.add("p2", p2);
+  m.add("p3", p3);
   const map<vector<string>, Parameter *> params = m.get_all_parameters();
   EXPECT_EQ(3u, params.size());
   EXPECT_EQ(&p1, params.at(vector<string> { "p1" }));
@@ -271,11 +271,11 @@ TEST_F(ModelTest, CheckGetAllParameters) {
 TEST_F(ModelTest, CheckGetAllParametersWithSubmodels) {
   Model m1, m2, m3;
   Parameter p1, p2, p3;
-  m1.add_parameter("p", p1);
-  m2.add_parameter("p", p2);
-  m3.add_parameter("p", p3);
-  m1.add_submodel("sm", m2);
-  m2.add_submodel("sm", m3);
+  m1.add("p", p1);
+  m2.add("p", p2);
+  m3.add("p", p3);
+  m1.add("sm", m2);
+  m2.add("sm", m3);
 
   const map<vector<string>, Parameter *> params1 = m1.get_all_parameters();
   EXPECT_EQ(3u, params1.size());
@@ -296,9 +296,9 @@ TEST_F(ModelTest, CheckGetAllParametersWithSubmodels) {
 TEST_F(ModelTest, CheckGetTrainableParameters) {
   Model m;
   Parameter p1, p2, p3;
-  m.add_parameter("p1", p1);
-  m.add_parameter("p2", p2);
-  m.add_parameter("p3", p3);
+  m.add("p1", p1);
+  m.add("p2", p2);
+  m.add("p3", p3);
   const map<vector<string>, Parameter *> params = m.get_trainable_parameters();
   EXPECT_EQ(3u, params.size());
   EXPECT_EQ(&p1, params.at(vector<string> { "p1" }));
@@ -309,11 +309,11 @@ TEST_F(ModelTest, CheckGetTrainableParameters) {
 TEST_F(ModelTest, CheckGetTrainableParametersWithSubmodels) {
   Model m1, m2, m3;
   Parameter p1, p2, p3;
-  m1.add_parameter("p", p1);
-  m2.add_parameter("p", p2);
-  m3.add_parameter("p", p3);
-  m1.add_submodel("sm", m2);
-  m2.add_submodel("sm", m3);
+  m1.add("p", p1);
+  m2.add("p", p2);
+  m3.add("p", p3);
+  m1.add("sm", m2);
+  m2.add("sm", m3);
 
   const map<vector<string>, Parameter *> params1 = m1.get_trainable_parameters();
   EXPECT_EQ(3u, params1.size());
@@ -340,9 +340,9 @@ TEST_F(ModelTest, CheckSaveLoad_Same) {
   {
     Model m1, m2;
     Parameter p1(shape, values1), p2(shape, values2);
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     ASSERT_NO_THROW(m1.save(path));
   }
@@ -350,9 +350,9 @@ TEST_F(ModelTest, CheckSaveLoad_Same) {
   {
     Model m1, m2;
     Parameter p1, p2;
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     EXPECT_NO_THROW(m1.load(path));
     std::remove(path.c_str());
@@ -375,9 +375,9 @@ TEST_F(ModelTest, CheckSaveLoad_Insufficient) {
   {
     Model m1, m2;
     Parameter p1(shape, values1), p2(shape, values2);
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     ASSERT_NO_THROW(m1.save(path));
   }
@@ -385,8 +385,8 @@ TEST_F(ModelTest, CheckSaveLoad_Insufficient) {
   {
     Model m1, m2;
     Parameter p1;
-    m1.add_parameter("p", p1);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m1.add("sm", m2);
 
     EXPECT_THROW(m1.load(path), Error);
     std::remove(path.c_str());
@@ -402,9 +402,9 @@ TEST_F(ModelTest, CheckSaveLoad_Excessive) {
   {
     Model m1, m2;
     Parameter p1(shape, values1), p2(shape, values2);
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     ASSERT_NO_THROW(m1.save(path));
   }
@@ -412,10 +412,10 @@ TEST_F(ModelTest, CheckSaveLoad_Excessive) {
   {
     Model m1, m2;
     Parameter p1, p2, p3;
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m2.add_parameter("pp", p3);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m2.add("pp", p3);
+    m1.add("sm", m2);
 
     EXPECT_NO_THROW(m1.load(path));
     std::remove(path.c_str());
@@ -445,9 +445,9 @@ TEST_F(ModelTest, CheckSaveLoadWithStats) {
     p2.add_stats("b", shape);
     p1.stats("a").reset_by_vector(stats1);
     p2.stats("b").reset_by_vector(stats2);
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     ASSERT_NO_THROW(m1.save(path));
   }
@@ -455,9 +455,9 @@ TEST_F(ModelTest, CheckSaveLoadWithStats) {
   {
     Model m1, m2;
     Parameter p1, p2;
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     EXPECT_NO_THROW(m1.load(path));
     std::remove(path.c_str());
@@ -490,9 +490,9 @@ TEST_F(ModelTest, CheckSaveWithoutStats) {
     p2.add_stats("b", shape);
     p1.stats("a").reset_by_vector(stats1);
     p2.stats("b").reset_by_vector(stats2);
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     ASSERT_NO_THROW(m1.save(path, false));
   }
@@ -500,9 +500,9 @@ TEST_F(ModelTest, CheckSaveWithoutStats) {
   {
     Model m1, m2;
     Parameter p1, p2;
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     EXPECT_NO_THROW(m1.load(path));
     std::remove(path.c_str());
@@ -533,9 +533,9 @@ TEST_F(ModelTest, CheckLoadWithoutStats) {
     p2.add_stats("b", shape);
     p1.stats("a").reset_by_vector(stats1);
     p2.stats("b").reset_by_vector(stats2);
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     ASSERT_NO_THROW(m1.save(path));
   }
@@ -543,9 +543,9 @@ TEST_F(ModelTest, CheckLoadWithoutStats) {
   {
     Model m1, m2;
     Parameter p1, p2;
-    m1.add_parameter("p", p1);
-    m2.add_parameter("p", p2);
-    m1.add_submodel("sm", m2);
+    m1.add("p", p1);
+    m2.add("p", p2);
+    m1.add("sm", m2);
 
     EXPECT_NO_THROW(m1.load(path, false));
     std::remove(path.c_str());

--- a/test/optimizer_impl_test.cc
+++ b/test/optimizer_impl_test.cc
@@ -173,7 +173,7 @@ TEST_F(OptimizerImplTest, CheckSGDUpdate) {
 
   SGD optimizer;
   optimizer.set_learning_rate_scaling(.1);
-  optimizer.add_parameter(param);
+  optimizer.add(param);
 
   vector<vector<float>> expected_v {
     {9.9000000e-01, 1.9800000e+00, 2.9700000e+00, 3.9600000e+00},
@@ -271,7 +271,7 @@ TEST_F(OptimizerImplTest, CheckMomentumSGDUpdate) {
 
   MomentumSGD optimizer;
   optimizer.set_learning_rate_scaling(.1);
-  optimizer.add_parameter(param);
+  optimizer.add(param);
   ASSERT_TRUE(param.has_stats("MomentumSGD.m"));
   EXPECT_TRUE(vector_match(
         vector<float>(4, 0), param.stats("MomentumSGD.m").to_vector()));
@@ -381,7 +381,7 @@ TEST_F(OptimizerImplTest, CheckAdaGradUpdate) {
 
   AdaGrad optimizer;
   optimizer.set_learning_rate_scaling(.1);
-  optimizer.add_parameter(param);
+  optimizer.add(param);
   ASSERT_TRUE(param.has_stats("AdaGrad.m"));
   EXPECT_TRUE(vector_match(
         vector<float>(4, 0), param.stats("AdaGrad.m").to_vector()));
@@ -495,7 +495,7 @@ TEST_F(OptimizerImplTest, CheckRMSPropUpdate) {
 
   RMSProp optimizer;
   optimizer.set_learning_rate_scaling(.1);
-  optimizer.add_parameter(param);
+  optimizer.add(param);
   ASSERT_TRUE(param.has_stats("RMSProp.m"));
   EXPECT_TRUE(vector_match(
         vector<float>(4, 0), param.stats("RMSProp.m").to_vector()));
@@ -605,7 +605,7 @@ TEST_F(OptimizerImplTest, CheckAdaDeltaUpdate) {
 
   AdaDelta optimizer;
   optimizer.set_learning_rate_scaling(.1);
-  optimizer.add_parameter(param);
+  optimizer.add(param);
   ASSERT_TRUE(param.has_stats("AdaDelta.m1"));
   ASSERT_TRUE(param.has_stats("AdaDelta.m2"));
   EXPECT_TRUE(vector_match(
@@ -735,7 +735,7 @@ TEST_F(OptimizerImplTest, CheckAdamUpdate) {
 
   Adam optimizer;
   optimizer.set_learning_rate_scaling(.1);
-  optimizer.add_parameter(param);
+  optimizer.add(param);
   ASSERT_TRUE(param.has_stats("Adam.m1"));
   ASSERT_TRUE(param.has_stats("Adam.m2"));
   EXPECT_TRUE(vector_match(

--- a/test/optimizer_test.cc
+++ b/test/optimizer_test.cc
@@ -18,6 +18,11 @@ protected:
   devices::Naive dev;
 };
 
+TEST_F(OptimizerTest, CheckAddNothing) {
+  optimizers::SGD optimizer;
+  EXPECT_NO_THROW(optimizer.add());
+}
+
 TEST_F(OptimizerTest, CheckAddParameter) {
   Device::set_default(dev);
   optimizers::SGD optimizer;
@@ -25,17 +30,17 @@ TEST_F(OptimizerTest, CheckAddParameter) {
   Parameter param2;
   Parameter param3;
 
-  EXPECT_NO_THROW(optimizer.add_parameter(param1));
-  EXPECT_THROW(optimizer.add_parameter(param1), Error);
+  EXPECT_NO_THROW(optimizer.add(param1));
+  EXPECT_THROW(optimizer.add(param1), Error);
 
-  EXPECT_NO_THROW(optimizer.add_parameter(param2));
-  EXPECT_THROW(optimizer.add_parameter(param1), Error);
-  EXPECT_THROW(optimizer.add_parameter(param2), Error);
+  EXPECT_NO_THROW(optimizer.add(param2));
+  EXPECT_THROW(optimizer.add(param1), Error);
+  EXPECT_THROW(optimizer.add(param2), Error);
 
-  EXPECT_NO_THROW(optimizer.add_parameter(param3));
-  EXPECT_THROW(optimizer.add_parameter(param1), Error);
-  EXPECT_THROW(optimizer.add_parameter(param2), Error);
-  EXPECT_THROW(optimizer.add_parameter(param3), Error);
+  EXPECT_NO_THROW(optimizer.add(param3));
+  EXPECT_THROW(optimizer.add(param1), Error);
+  EXPECT_THROW(optimizer.add(param2), Error);
+  EXPECT_THROW(optimizer.add(param3), Error);
 }
 
 TEST_F(OptimizerTest, CheckAddModel) {
@@ -45,15 +50,15 @@ TEST_F(OptimizerTest, CheckAddModel) {
   Parameter param1;
   Parameter param2;
   Parameter param3;
-  m.add_parameter("param1", param1);
-  m.add_parameter("param2", param2);
-  m.add_parameter("param3", param3);
+  m.add("param1", param1);
+  m.add("param2", param2);
+  m.add("param3", param3);
 
-  EXPECT_NO_THROW(optimizer.add_model(m));
-  EXPECT_THROW(optimizer.add_model(m), Error);
-  EXPECT_THROW(optimizer.add_parameter(param1), Error);
-  EXPECT_THROW(optimizer.add_parameter(param2), Error);
-  EXPECT_THROW(optimizer.add_parameter(param3), Error);
+  EXPECT_NO_THROW(optimizer.add(m));
+  EXPECT_THROW(optimizer.add(m), Error);
+  EXPECT_THROW(optimizer.add(param1), Error);
+  EXPECT_THROW(optimizer.add(param2), Error);
+  EXPECT_THROW(optimizer.add(param3), Error);
 }
 
 TEST_F(OptimizerTest, CheckAddModelWithMultipleModels) {
@@ -63,19 +68,19 @@ TEST_F(OptimizerTest, CheckAddModelWithMultipleModels) {
   Parameter param1;
   Parameter param2;
   Parameter param3;
-  m1.add_parameter("param1", param1);
-  m2.add_parameter("param2", param2);
-  m3.add_parameter("param3", param3);
+  m1.add("param1", param1);
+  m2.add("param2", param2);
+  m3.add("param3", param3);
 
-  EXPECT_NO_THROW(optimizer.add_model(m1));
-  EXPECT_NO_THROW(optimizer.add_model(m2));
-  EXPECT_NO_THROW(optimizer.add_model(m3));
-  EXPECT_THROW(optimizer.add_model(m1), Error);
-  EXPECT_THROW(optimizer.add_model(m2), Error);
-  EXPECT_THROW(optimizer.add_model(m3), Error);
-  EXPECT_THROW(optimizer.add_parameter(param1), Error);
-  EXPECT_THROW(optimizer.add_parameter(param2), Error);
-  EXPECT_THROW(optimizer.add_parameter(param3), Error);
+  EXPECT_NO_THROW(optimizer.add(m1));
+  EXPECT_NO_THROW(optimizer.add(m2));
+  EXPECT_NO_THROW(optimizer.add(m3));
+  EXPECT_THROW(optimizer.add(m1), Error);
+  EXPECT_THROW(optimizer.add(m2), Error);
+  EXPECT_THROW(optimizer.add(m3), Error);
+  EXPECT_THROW(optimizer.add(param1), Error);
+  EXPECT_THROW(optimizer.add(param2), Error);
+  EXPECT_THROW(optimizer.add(param3), Error);
 }
 
 TEST_F(OptimizerTest, CheckAddModelWithSubmodels) {
@@ -85,19 +90,72 @@ TEST_F(OptimizerTest, CheckAddModelWithSubmodels) {
   Parameter param1;
   Parameter param2;
   Parameter param3;
-  m.add_parameter("param1", param1);
-  sm.add_parameter("param2", param2);
-  ssm.add_parameter("param3", param3);
-  m.add_submodel("sm", sm);
-  sm.add_submodel("ssm", ssm);
+  m.add("param1", param1);
+  sm.add("param2", param2);
+  ssm.add("param3", param3);
+  m.add("sm", sm);
+  sm.add("ssm", ssm);
 
-  EXPECT_NO_THROW(optimizer.add_model(m));
-  EXPECT_THROW(optimizer.add_model(m), Error);
-  EXPECT_THROW(optimizer.add_model(sm), Error);
-  EXPECT_THROW(optimizer.add_model(ssm), Error);
-  EXPECT_THROW(optimizer.add_parameter(param1), Error);
-  EXPECT_THROW(optimizer.add_parameter(param2), Error);
-  EXPECT_THROW(optimizer.add_parameter(param3), Error);
+  EXPECT_NO_THROW(optimizer.add(m));
+  EXPECT_THROW(optimizer.add(m), Error);
+  EXPECT_THROW(optimizer.add(sm), Error);
+  EXPECT_THROW(optimizer.add(ssm), Error);
+  EXPECT_THROW(optimizer.add(param1), Error);
+  EXPECT_THROW(optimizer.add(param2), Error);
+  EXPECT_THROW(optimizer.add(param3), Error);
+}
+
+TEST_F(OptimizerTest, CheckAddMultipleParameters) {
+  Device::set_default(dev);
+  optimizers::SGD optimizer;
+  Parameter param1, param2, param3, param4;
+
+  EXPECT_NO_THROW(optimizer.add(param1, param2, param3));
+  EXPECT_THROW(optimizer.add(param1), Error);
+  EXPECT_THROW(optimizer.add(param2), Error);
+  EXPECT_THROW(optimizer.add(param3), Error);
+  EXPECT_THROW(optimizer.add(param1, param2), Error);
+  EXPECT_THROW(optimizer.add(param2, param3), Error);
+  EXPECT_THROW(optimizer.add(param1, param3), Error);
+  EXPECT_THROW(optimizer.add(param1, param2, param3), Error);
+  EXPECT_NO_THROW(optimizer.add(param4));
+}
+
+TEST_F(OptimizerTest, CheckAddMultipleModels) {
+  Device::set_default(dev);
+  optimizers::SGD optimizer;
+  Parameter p1, p2, p3, p4;
+  Model m1, m2, m3, m4;
+  m1.add("p", p1);
+  m2.add("p", p2);
+  m3.add("p", p3);
+  m4.add("p", p4);
+
+  EXPECT_NO_THROW(optimizer.add(m1, m2, m3));
+  EXPECT_THROW(optimizer.add(m1), Error);
+  EXPECT_THROW(optimizer.add(m2), Error);
+  EXPECT_THROW(optimizer.add(m3), Error);
+  EXPECT_THROW(optimizer.add(m1, m2), Error);
+  EXPECT_THROW(optimizer.add(m2, m3), Error);
+  EXPECT_THROW(optimizer.add(m1, m3), Error);
+  EXPECT_THROW(optimizer.add(m1, m2, m3), Error);
+  EXPECT_NO_THROW(optimizer.add(m4));
+}
+
+TEST_F(OptimizerTest, CheckAddParameterAndModelSimultaneously) {
+  Device::set_default(dev);
+  optimizers::SGD optimizer;
+  Parameter p1, p2, p3, p4;
+  Model m1, m2;
+  m1.add("p", p1);
+  m2.add("p", p2);
+
+  EXPECT_NO_THROW(optimizer.add(m1, p3));
+  EXPECT_THROW(optimizer.add(m1), Error);
+  EXPECT_THROW(optimizer.add(p3), Error);
+  EXPECT_THROW(optimizer.add(m1, p3), Error);
+  EXPECT_NO_THROW(optimizer.add(m2));
+  EXPECT_NO_THROW(optimizer.add(p4));
 }
 
 TEST_F(OptimizerTest, CheckEpoch) {
@@ -132,7 +190,7 @@ TEST_F(OptimizerTest, CheckWeightDecay) {
   ASSERT_EQ(.0f, optimizer.get_weight_decay());
 
   Parameter param({2, 2}, {0, 0, 0, 0});
-  optimizer.add_parameter(param);
+  optimizer.add(param);
 
   struct TestCase {
     float strength;
@@ -167,7 +225,7 @@ TEST_F(OptimizerTest, CheckGradientClipping) {
   ASSERT_EQ(.0f, optimizer.get_gradient_clipping());
 
   Parameter param({2, 2}, {0, 0, 0, 0});
-  optimizer.add_parameter(param);
+  optimizer.add(param);
 
   struct TestCase {
     float threshold;


### PR DESCRIPTION
This PR modifies the function name `add_foo` in `Optimizer` and `Model` to `add`.
And this also allows syntax below:

```c++
optimizer.add(param1, param2, param3, ...);  // registering multiple parameters.
optimizer.add(model1, model2, model3, ...);  // registering multiple models.
optimizer.add(param1, model1, param2, model2, ...);  // registering both parameters and models.
```