### PR TITLE
Remove get_default() function from all default arguments

### DIFF
--- a/primitiv/mixins.h
+++ b/primitiv/mixins.h
@@ -129,6 +129,19 @@ public:
   static void set_default(T &obj) {
     default_obj_ = &obj;
   }
+
+  /**
+   * Obtains the reference of the object pointed by a pointer, or obtains the
+   * default object.
+   * @param ptr Pointer of an object, or `nullptr`.
+   * @return Reference of the object pointed by `ptr`,
+   *         or reference of the default object if `ptr` is `nullptr`.
+   * @throw primitiv::Error `nullptr` is given by `ptr` although the default
+   *                        object is also null.
+   */
+  static T &get_reference_or_default(T *ptr) {
+    return ptr ? *ptr : get_default();
+  }
 };
 
 template<typename T>

--- a/primitiv/model.cc
+++ b/primitiv/model.cc
@@ -1,6 +1,7 @@
 #include <config.h>
 
 #include <fstream>
+#include <primitiv/device.h>
 #include <primitiv/error.h>
 #include <primitiv/file_format.h>
 #include <primitiv/model.h>
@@ -9,10 +10,18 @@
 #include <primitiv/parameter.h>
 #include <primitiv/string_utils.h>
 
+namespace {
+
+// Helper to obtain a Device object from a pointer.
+primitiv::Device &get_device(primitiv::Device *device) {
+  return device ? *device : primitiv::Device::get_default();
+}
+
+}  // namespace
+
 namespace primitiv {
 
-void Model::load(
-    const std::string &path, bool with_stats, Device &device) {
+void Model::load(const std::string &path, bool with_stats, Device *device) {
   std::ifstream ifs(path);
   if (!ifs.is_open()) {
     THROW_ERROR("Could not open file: " << path);
@@ -40,7 +49,7 @@ void Model::load(
           "Model does not have a parameter with name: '"
           << string_utils::join(key, ".") << "'");
     }
-    it->second->load_inner(reader, with_stats, device);
+    it->second->load_inner(reader, with_stats, ::get_device(device));
   }
 }
 
@@ -138,7 +147,8 @@ const Model &Model::get_submodel(const std::vector<std::string> &names) const {
   return *it->second;
 }
 
-std::map<std::vector<std::string>, Parameter *> Model::get_all_parameters() const {
+std::map<std::vector<std::string>, Parameter *> Model::get_all_parameters(
+    ) const {
   std::map<std::vector<std::string>, Parameter *> params;
   for (const auto &kv : param_kv_) {
     params.emplace(std::vector<std::string> { kv.first }, kv.second);

--- a/primitiv/model.cc
+++ b/primitiv/model.cc
@@ -10,15 +10,6 @@
 #include <primitiv/parameter.h>
 #include <primitiv/string_utils.h>
 
-namespace {
-
-// Helper to obtain a Device object from a pointer.
-primitiv::Device &get_device(primitiv::Device *device) {
-  return device ? *device : primitiv::Device::get_default();
-}
-
-}  // namespace
-
 namespace primitiv {
 
 void Model::load(const std::string &path, bool with_stats, Device *device) {
@@ -49,7 +40,8 @@ void Model::load(const std::string &path, bool with_stats, Device *device) {
           "Model does not have a parameter with name: '"
           << string_utils::join(key, ".") << "'");
     }
-    it->second->load_inner(reader, with_stats, ::get_device(device));
+    it->second->load_inner(
+        reader, with_stats, Device::get_reference_or_default(device));
   }
 }
 

--- a/primitiv/model.h
+++ b/primitiv/model.h
@@ -8,12 +8,12 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <primitiv/device.h>
 #include <primitiv/error.h>
 #include <primitiv/mixins.h>
 
 namespace primitiv {
 
+class Device;
 class Parameter;
 
 /**
@@ -30,16 +30,50 @@ public:
    * @param with_stats Whether or not to load all additional statistics.
    * @param device Device object to manage parameters.
    */
-  void load(const std::string &path,
-      bool with_stats = true,
-      Device &device = Device::get_default());
+  void load(const std::string &path, bool with_stats, Device *device);
+
+  /**
+   * Loads all parameters from a file.
+   * @param path Path of the file.
+   * @param with_stats Whether or not to load all additional statistics.
+   * @param device Device object to manage parameters.
+   */
+  void load(const std::string &path, bool with_stats, Device &device) {
+    load(path, with_stats, &device);
+  }
+
+  /**
+   * Loads all parameters from a file.
+   * @param path Path of the file.
+   * @param with_stats Whether or not to load all additional statistics.
+   */
+  void load(const std::string &path, bool with_stats) {
+    load(path, with_stats, nullptr);
+  }
+
+  /**
+   * Loads all parameters from a file.
+   * @param path Path of the file.
+   * @param with_stats Whether or not to load all additional statistics.
+   */
+  void load(const std::string &path) {
+    load(path, true, nullptr);
+  }
 
   /**
    * Saves all parameters to a file.
    * @param path Path of the file.
    * @param with_stats Whether or not to save all additional statistics.
    */
-  void save(const std::string &path, bool with_stats = true) const;
+  void save(const std::string &path, bool with_stats) const;
+
+  /**
+   * Saves all parameters to a file.
+   * @param path Path of the file.
+   */
+  void save(const std::string &path) const {
+    save(path, true);
+  }
 
   /**
    * Registers a new parameter.
@@ -199,7 +233,8 @@ public:
    * Retrieves trainable parameters in the model.
    * @return Dictionary of parameters.
    */
-  std::map<std::vector<std::string>, Parameter *> get_trainable_parameters() const {
+  std::map<std::vector<std::string>, Parameter *> get_trainable_parameters(
+      ) const {
     // NOTE(odashi):
     // Currently this function returns all parameters.
     return get_all_parameters();

--- a/primitiv/node_funcs.cc
+++ b/primitiv/node_funcs.cc
@@ -5,6 +5,7 @@
 
 #include <vector>
 
+#include <primitiv/device.h>
 #include <primitiv/error.h>
 #include <primitiv/functions.h>
 #include <primitiv/graph.h>

--- a/primitiv/node_funcs.cc
+++ b/primitiv/node_funcs.cc
@@ -22,16 +22,6 @@ namespace {
 
 using primitiv::Node;
 
-// Helper to obtain Device object.
-primitiv::Device &get_device(primitiv::Device *dev) {
-  return dev ? *dev : primitiv::Device::get_default();
-}
-
-// Helper to obtain Graph object.
-primitiv::Graph &get_graph(primitiv::Graph *g) {
-  return g ? *g : primitiv::Graph::get_default();
-}
-
 // Helper to transform pointers to nodes.
 std::vector<Node> ptr_to_obj(const std::vector<const Node *> &xs) {
   std::vector<Node> ret;
@@ -43,7 +33,6 @@ std::vector<Node> ptr_to_obj(const std::vector<const Node *> &xs) {
 }  // namespace
 
 namespace primitiv {
-
 namespace functions {
 
 template<>
@@ -106,25 +95,30 @@ Node divide(const Node &a, const Node &b) {
 
 Node input_node(
     const Shape &shape, const std::vector<float> &data, Device *dev, Graph *g) {
-  return REG(::get_graph(g), Input(shape, data, ::get_device(dev)));
+  return REG(
+      Graph::get_reference_or_default(g),
+      Input(shape, data, Device::get_reference_or_default(dev)));
 }
 
 Node parameter_node(Parameter &param, Graph *g) {
-  return REG(::get_graph(g), ParameterInput(param));
+  return REG(Graph::get_reference_or_default(g), ParameterInput(param));
 }
 
 template<>
 Node copy(const Node &x, Device *dev) {
-  return REGX(x, Copy(::get_device(dev)), x);
+  return REGX(x, Copy(Device::get_reference_or_default(dev)), x);
 }
 
 template<>
-Node pick(const Node &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
+Node pick(
+    const Node &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
   return REGX(x, Pick(ids, dim), x);
 }
 
 template<>
-Node slice(const Node &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper) {
+Node slice(
+    const Node &x, std::uint32_t dim,
+    std::uint32_t lower, std::uint32_t upper) {
   return REGX(x, Slice(dim, lower, upper), x);
 }
 
@@ -276,11 +270,15 @@ Node sum(const Node &x) {
 }  // namespace batch
 
 Node constant_node(const Shape &shape, float k, Device *dev, Graph *g) {
-  return REG(::get_graph(g), Constant(shape, k, ::get_device(dev)));
+  return REG(
+      Graph::get_reference_or_default(g),
+      Constant(shape, k, Device::get_reference_or_default(dev)));
 }
 
 Node identity_node(std::uint32_t size, Device *dev, Graph *g) {
-  return REG(::get_graph(g), IdentityMatrix(size, ::get_device(dev)));
+  return REG(
+      Graph::get_reference_or_default(g),
+      IdentityMatrix(size, Device::get_reference_or_default(dev)));
 }
 
 namespace random {
@@ -288,25 +286,30 @@ namespace random {
 Node bernoulli_node(
     const Shape &shape, float p, Device *dev, Graph *g) {
   return REG(
-      ::get_graph(g), RandomBernoulli(shape, p, ::get_device(dev)));
+      Graph::get_reference_or_default(g),
+      RandomBernoulli(shape, p, Device::get_reference_or_default(dev)));
 }
 
 Node uniform_node(
     const Shape &shape, float lower, float upper, Device *dev, Graph *g) {
   return REG(
-      ::get_graph(g), RandomUniform(shape, lower, upper, ::get_device(dev)));
+      Graph::get_reference_or_default(g),
+      RandomUniform(
+        shape, lower, upper, Device::get_reference_or_default(dev)));
 }
 
 Node normal_node(
     const Shape &shape, float mean, float sd, Device *dev, Graph *g) {
   return REG(
-      ::get_graph(g), RandomNormal(shape, mean, sd, ::get_device(dev)));
+      Graph::get_reference_or_default(g),
+      RandomNormal(shape, mean, sd, Device::get_reference_or_default(dev)));
 }
 
 Node log_normal_node(
     const Shape &shape, float mean, float sd, Device *dev, Graph *g) {
   return REG(
-      ::get_graph(g), RandomLogNormal(shape, mean, sd, ::get_device(dev)));
+      Graph::get_reference_or_default(g),
+      RandomLogNormal(shape, mean, sd, Device::get_reference_or_default(dev)));
 }
 
 Node gumbel_node(
@@ -317,5 +320,4 @@ Node gumbel_node(
 }  // namespace random
 
 }  // namespace functions
-
 }  // namespace primitiv

--- a/primitiv/operator_impl.cc
+++ b/primitiv/operator_impl.cc
@@ -1,6 +1,7 @@
 #include <config.h>
 
 #include <algorithm>
+#include <primitiv/device.h>
 #include <primitiv/error.h>
 #include <primitiv/functions.h>
 #include <primitiv/operator_impl.h>

--- a/primitiv/optimizer_impl.h
+++ b/primitiv/optimizer_impl.h
@@ -29,7 +29,7 @@ public:
    * Creates a new SGD object.
    * @param eta Learning rate.
    */
-  explicit SGD(const float eta = 0.1) : eta_(eta) {}
+  explicit SGD(float eta = 0.1) : eta_(eta) {}
 
   /**
    * Returns the learning rate.

--- a/primitiv/parameter.cc
+++ b/primitiv/parameter.cc
@@ -13,11 +13,6 @@ using std::vector;
 
 namespace {
 
-// Obtains reference of the Device object.
-primitiv::Device &get_device(primitiv::Device *device) {
-  return device ? *device : primitiv::Device::get_default();
-}
-
 // Reads Shape data.
 primitiv::Shape read_shape(primitiv::msgpack::Reader &reader) {
   std::vector<std::uint32_t> dims;
@@ -84,7 +79,7 @@ namespace primitiv {
 Parameter::Parameter(
     const Shape &shape, const vector<float> & value, Device *device)
 : shape_(shape)
-, device_(&::get_device(device))
+, device_(&Device::get_reference_or_default(device))
 , value_(functions::input<Tensor>(shape, value, device_))
 , grad_(functions::zeros<Tensor>(shape, device_)) {
   ::assert_shape(value_, grad_);
@@ -93,7 +88,7 @@ Parameter::Parameter(
 Parameter::Parameter(
     const Shape &shape, const Initializer &initializer, Device *device)
 : shape_(shape)
-, device_(&::get_device(device))
+, device_(&Device::get_reference_or_default(device))
 , value_(functions::zeros<Tensor>(shape, device_))
 , grad_(functions::zeros<Tensor>(shape, device_)) {
   ::assert_shape(value_, grad_);
@@ -102,7 +97,7 @@ Parameter::Parameter(
 
 void Parameter::init(
     const Shape &shape, const std::vector<float> &value, Device *device) {
-  Device &device_temp = ::get_device(device);
+  Device &device_temp = Device::get_reference_or_default(device);
 
   Tensor value_temp = functions::input<Tensor>(shape, value, device_temp);
   Tensor grad_temp = functions::zeros<Tensor>(shape, device_temp);
@@ -118,7 +113,7 @@ void Parameter::init(
 
 void Parameter::init(
     const Shape &shape, const Initializer &initializer, Device *device) {
-  Device &device_temp = ::get_device(device);
+  Device &device_temp = Device::get_reference_or_default(device);
 
   Tensor value_temp = functions::zeros<Tensor>(shape, device_temp);
   Tensor grad_temp = functions::zeros<Tensor>(shape, device_temp);
@@ -195,7 +190,7 @@ void Parameter::load(const string &path, bool with_stats, Device *device) {
   reader >> datatype;
   FileFormat::assert_datatype(FileFormat::DataType::PARAMETER, datatype);
 
-  load_inner(reader, with_stats, ::get_device(device));
+  load_inner(reader, with_stats, Device::get_reference_or_default(device));
 }
 
 void Parameter::save(const string &path, bool with_stats) const  {

--- a/primitiv/parameter.h
+++ b/primitiv/parameter.h
@@ -4,7 +4,6 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <primitiv/device.h>
 #include <primitiv/error.h>
 #include <primitiv/mixins.h>
 #include <primitiv/msgpack/reader.h>
@@ -14,6 +13,7 @@
 
 namespace primitiv {
 
+class Device;
 class Initializer;
 
 /**
@@ -52,9 +52,27 @@ public:
    * @param device The device object to manage internal memory.
    */
   Parameter(
-      const Shape &shape,
-      const std::vector<float> &value,
-      Device &device = Device::get_default());
+      const Shape &shape, const std::vector<float> &value, Device *device);
+
+  /**
+   * Creates a new Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param value List of initial values. Order of elements should be the
+   *              column-major (Fortran) order.
+   * @param device The device object to manage internal memory.
+   */
+  Parameter(
+      const Shape &shape, const std::vector<float> &value, Device &device)
+    : Parameter(shape, value, &device) {}
+
+  /**
+   * Creates a new Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param value List of initial values. Order of elements should be the
+   *              column-major (Fortran) order.
+   */
+  Parameter(const Shape &shape, const std::vector<float> &value)
+    : Parameter(shape, value, nullptr) {}
 
   /**
    * Creates a new Parameter object.
@@ -63,9 +81,25 @@ public:
    * @param device The device object to manage internal memory.
    */
   Parameter(
-      const Shape &shape,
-      const Initializer &initializer,
-      Device &device = Device::get_default());
+      const Shape &shape, const Initializer &initializer, Device *device);
+
+  /**
+   * Creates a new Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param init An Initializer object.
+   * @param device The device object to manage internal memory.
+   */
+  Parameter(
+      const Shape &shape, const Initializer &initializer, Device &device)
+    : Parameter(shape, initializer, &device) {}
+
+  /**
+   * Creates a new Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param init An Initializer object.
+   */
+  Parameter(const Shape &shape, const Initializer &initializer)
+    : Parameter(shape, initializer, nullptr) {}
 
   /**
    * Initializes the Parameter object.
@@ -75,9 +109,29 @@ public:
    * @param device The device object to manage internal memory.
    */
   void init(
-      const Shape &shape,
-      const std::vector<float> &value,
-      Device &device = Device::get_default());
+      const Shape &shape, const std::vector<float> &value, Device *device);
+
+  /**
+   * Initializes the Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param value List of initial values. Order of elements should be the
+   *              column-major (Fortran) order.
+   * @param device The device object to manage internal memory.
+   */
+  void init(
+      const Shape &shape, const std::vector<float> &value, Device &device) {
+    init(shape, value, &device);
+  }
+
+  /**
+   * Initializes the Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param value List of initial values. Order of elements should be the
+   *              column-major (Fortran) order.
+   */
+  void init(const Shape &shape, const std::vector<float> &value) {
+    init(shape, value, nullptr);
+  }
 
   /**
    * Initializes the Parameter object.
@@ -86,9 +140,28 @@ public:
    * @param device The device object to manage internal memory.
    */
   void init(
-      const Shape &shape,
-      const Initializer &initializer,
-      Device &device = Device::get_default());
+      const Shape &shape, const Initializer &initializer, Device *device);
+
+  /**
+   * Initializes the Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param init An Initializer object.
+   * @param device The device object to manage internal memory.
+   */
+  void init(
+      const Shape &shape, const Initializer &initializer, Device &device) {
+    init(shape, initializer, &device);
+  }
+
+  /**
+   * Initializes the Parameter object.
+   * @param shape The shape of the parameter. The batch size should be 1.
+   * @param init An Initializer object.
+   */
+  void init(
+      const Shape &shape, const Initializer &initializer) {
+    init(shape, initializer, nullptr);
+  }
 
   /**
    * Loads parameters from specified file.
@@ -97,10 +170,36 @@ public:
    *                   as parameter values if the file has them.
    * @param device The device object to manage internal memory.
    */
-  void load(
-      const std::string &path,
-      bool with_stats = true,
-      Device &device = Device::get_default());
+  void load(const std::string &path, bool with_stats, Device *device);
+
+  /**
+   * Loads parameters from specified file.
+   * @param path File path to load parameters.
+   * @param with_stats Whether or not to load all additional statistics as well
+   *                   as parameter values if the file has them.
+   * @param device The device object to manage internal memory.
+   */
+  void load(const std::string &path, bool with_stats, Device &device) {
+    load(path, with_stats, &device);
+  }
+
+  /**
+   * Loads parameters from specified file.
+   * @param path File path to load parameters.
+   * @param with_stats Whether or not to load all additional statistics as well
+   *                   as parameter values if the file has them.
+   */
+  void load(const std::string &path, bool with_stats) {
+    load(path, with_stats, nullptr);
+  }
+
+  /**
+   * Loads parameters from specified file.
+   * @param path File path to load parameters.
+   */
+  void load(const std::string &path) {
+    load(path, true, nullptr);
+  }
 
   /**
    * Saves current parameters into specified file.
@@ -108,7 +207,15 @@ public:
    * @param with_stats Whether or not to save all additional statistics as well
    *                   as parameter values if the parameter object has them.
    */
-  void save(const std::string &path, bool with_stats = true) const;
+  void save(const std::string &path, bool with_stats) const;
+
+  /**
+   * Saves current parameters into specified file.
+   * @param path File path to save parameters.
+   */
+  void save(const std::string &path) const {
+    save(path, true);
+  }
 
   /**
    * Returns whether the parameter is valid or not.

--- a/primitiv/tensor.cc
+++ b/primitiv/tensor.cc
@@ -40,7 +40,7 @@ void *Tensor::data() {
   return data_.get();
 }
 
-void Tensor::reset(const float k) {
+void Tensor::reset(float k) {
   if (!valid()) THROW_ERROR("Invalid tensor.");
   device_->reset_tensor(k, *this);
 }

--- a/primitiv/tensor.h
+++ b/primitiv/tensor.h
@@ -119,7 +119,7 @@ public:
    * Reset internal values using a constant.
    * @param k A value to be used to initialize each element.
    */
-  void reset(const float k);
+  void reset(float k);
 
   /**
    * Reset internal values using a vector.

--- a/test/mixins_test.cc
+++ b/test/mixins_test.cc
@@ -35,28 +35,45 @@ TEST_F(MixinsTest, CheckIdentifiable) {
 TEST_F(MixinsTest, CheckDefaultSettable) {
   class TestClass : public DefaultSettable<TestClass> {};
 
+  TestClass obj0;
+
   EXPECT_THROW(TestClass::get_default(), Error);
+  EXPECT_THROW(TestClass::get_reference_or_default(nullptr), Error);
+  EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
+
   {
     TestClass obj1;
     TestClass::set_default(obj1);
     EXPECT_EQ(&obj1, &TestClass::get_default());
+    EXPECT_EQ(&obj1, &TestClass::get_reference_or_default(nullptr));
+    EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
 
     {
       TestClass obj2;
       TestClass::set_default(obj2);
       EXPECT_EQ(&obj2, &TestClass::get_default());
+      EXPECT_EQ(&obj2, &TestClass::get_reference_or_default(nullptr));
+      EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
 
       TestClass obj3;
       TestClass::set_default(obj3);
       EXPECT_EQ(&obj3, &TestClass::get_default());
+      EXPECT_EQ(&obj3, &TestClass::get_reference_or_default(nullptr));
+      EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
     }
     EXPECT_THROW(TestClass::get_default(), Error);
+    EXPECT_THROW(TestClass::get_reference_or_default(nullptr), Error);
+    EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
 
     TestClass obj4;
     TestClass::set_default(obj4);
     EXPECT_EQ(&obj4, &TestClass::get_default());
+    EXPECT_EQ(&obj4, &TestClass::get_reference_or_default(nullptr));
+    EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
   }
   EXPECT_THROW(TestClass::get_default(), Error);
+  EXPECT_THROW(TestClass::get_reference_or_default(nullptr), Error);
+  EXPECT_EQ(&obj0, &TestClass::get_reference_or_default(&obj0));
 }
 
 }  // namespace mixins


### PR DESCRIPTION
This PR adds some overloaded functions to `Parameter` and `Model` mainly to avoid default arguments. Default devices/graphs can be specified by passing `nullptr` to the new interface, and `get_default` functions are finally omitted from default arguments.