### PR TITLE
Refactoring about Tensor

### DIFF
--- a/primitiv/tensor.cc
+++ b/primitiv/tensor.cc
@@ -7,7 +7,7 @@
 namespace primitiv {
 
 float Tensor::to_float() const {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   if (shape_.size() != 1) {
     THROW_ERROR(
         "Tensor has more than 1 values. shape = " << shape_.to_string());
@@ -16,22 +16,22 @@ float Tensor::to_float() const {
 }
 
 std::vector<float> Tensor::to_vector() const {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   return device_->tensor_to_vector(*this);
 }
 
 std::vector<std::uint32_t> Tensor::argmax(std::uint32_t dim) const {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   return device_->argmax(*this, dim);
 }
 
 std::vector<std::uint32_t> Tensor::argmin(std::uint32_t dim) const {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   return device_->argmin(*this, dim);
 }
 
 void *Tensor::data() {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   // If the internal memory is shared with other objects, the memory will be
   // duplicated to maintain the safety of other objects.
   if (data_.use_count() > 1) {
@@ -41,44 +41,44 @@ void *Tensor::data() {
 }
 
 void Tensor::reset(float k) {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   device_->reset_tensor(k, *this);
 }
 
 void Tensor::reset_by_array(const float *values) {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   device_->reset_tensor_by_array(values, *this);
 }
 
 void Tensor::reset_by_vector(const std::vector<float> &values) {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   device_->reset_tensor_by_vector(values, *this);
 }
 
 Tensor Tensor::reshape(const Shape &new_shape) const {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   return Tensor(shape_ops::reshape(shape_, new_shape), *device_, data_);
 }
 
 Tensor Tensor::flatten() const {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   return Tensor(shape_ops::flatten(shape_), *device_, data_);
 }
 
 Tensor &Tensor::inplace_multiply_const(float k) {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   device_->inplace_multiply_const(k, *this);
   return *this;
 }
 
 Tensor &Tensor::inplace_add(const Tensor &x) {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   device_->inplace_add(x, *this);
   return *this;
 }
 
 Tensor &Tensor::inplace_subtract(const Tensor &x) {
-  if (!valid()) THROW_ERROR("Invalid tensor.");
+  check_valid();
   device_->inplace_subtract(x, *this);
   return *this;
 }

--- a/primitiv/tensor.h
+++ b/primitiv/tensor.h
@@ -53,11 +53,21 @@ public:
   bool valid() const { return !!device_; }
 
   /**
+   * Check whether the object is valid or not.
+   * @throw primitiv::Error This object is invalid.
+   */
+  void check_valid() const {
+    if (!valid()) {
+      THROW_ERROR("Invalid Tensor object.");
+    }
+  }
+
+  /**
    * Returns the shape of the Tensor.
    * @return Shape of the Tensor.
    */
   Shape shape() const {
-    if (!valid()) THROW_ERROR("Invalid tensor.");
+    check_valid();
     return shape_;
   }
 
@@ -66,7 +76,7 @@ public:
    * @return Device object.
    */
   Device &device() const {
-    if (!valid()) THROW_ERROR("Invalid tensor.");
+    check_valid();
     return *device_;
   }
 
@@ -81,7 +91,7 @@ public:
    * @return Const-pointer of the internal memory.
    */
   const void *data() const {
-    if (!valid()) THROW_ERROR("Invalid tensor.");
+    check_valid();
     return data_.get();
   }
 

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -438,8 +438,6 @@ TEST_F(TensorTest, CheckInplaceMultiplyConst) {
       x *= 2;
       EXPECT_TRUE(vector_match(y1_data, x.to_vector()));
     }
-  }
-  for (Device *dev : devices) {
     {
       Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), x_data);
       x.inplace_multiply_const(.5);
@@ -449,6 +447,59 @@ TEST_F(TensorTest, CheckInplaceMultiplyConst) {
       Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), x_data);
       x *= .5;
       EXPECT_TRUE(vector_match(y2_data, x.to_vector()));
+    }
+  }
+}
+
+TEST_F(TensorTest, CheckCopyAndInplaceMultiplyConst) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y1_data {2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
+  const vector<float> y2_data {.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 5.5, 6};
+
+  for (Device *dev : devices) {
+    {
+      Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), x_data);
+
+      const Tensor copied = x;
+      EXPECT_EQ(static_cast<const Tensor>(x).data(), copied.data());
+
+      x.inplace_multiply_const(2);
+      EXPECT_NE(static_cast<const Tensor>(x).data(), copied.data());
+      EXPECT_TRUE(vector_match(y1_data, x.to_vector()));
+      EXPECT_TRUE(vector_match(x_data, copied.to_vector()));
+    }
+    {
+      Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), x_data);
+
+      const Tensor copied = x;
+      EXPECT_EQ(static_cast<const Tensor>(x).data(), copied.data());
+
+      x *= 2;
+      EXPECT_NE(static_cast<const Tensor>(x).data(), copied.data());
+      EXPECT_TRUE(vector_match(y1_data, x.to_vector()));
+      EXPECT_TRUE(vector_match(x_data, copied.to_vector()));
+    }
+    {
+      Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), x_data);
+
+      const Tensor copied = x;
+      EXPECT_EQ(static_cast<const Tensor>(x).data(), copied.data());
+
+      x.inplace_multiply_const(.5);
+      EXPECT_NE(static_cast<const Tensor>(x).data(), copied.data());
+      EXPECT_TRUE(vector_match(y2_data, x.to_vector()));
+      EXPECT_TRUE(vector_match(x_data, copied.to_vector()));
+    }
+    {
+      Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), x_data);
+
+      const Tensor copied = x;
+      EXPECT_EQ(static_cast<const Tensor>(x).data(), copied.data());
+
+      x *= .5;
+      EXPECT_NE(static_cast<const Tensor>(x).data(), copied.data());
+      EXPECT_TRUE(vector_match(y2_data, x.to_vector()));
+      EXPECT_TRUE(vector_match(x_data, copied.to_vector()));
     }
   }
 }
@@ -673,6 +724,7 @@ TEST_F(TensorTest, CheckArgMaxDims) {
     {1, 1, 1, 1, 1, 1},
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
   };
+
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({3, 3}, 2), data);
     for (const std::uint32_t i : {0u, 1u, 2u}) {
@@ -686,6 +738,7 @@ TEST_F(TensorTest, CheckArgMaxLarge) {
   const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
+
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
       vector<float> data(n);
@@ -708,6 +761,7 @@ TEST_F(TensorTest, CheckArgMinDims) {
     {1, 1, 1, 1, 1, 1},
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
   };
+
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({3, 3}, 2), data);
     for (const std::uint32_t i : {0u, 1u, 2u}) {
@@ -721,6 +775,7 @@ TEST_F(TensorTest, CheckArgMinLarge) {
   const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
+
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
       vector<float> data(n);


### PR DESCRIPTION
- Add a missing test `TensorTest.CheckCopyAndInplaceMultiplyConst`.
- Add `Tensor::check_valid()` function that throws when the tensor is invalid.