### PR TITLE
Add explicitly invalidating Tensor object.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.1.0 FATAL_ERROR)
 set(CMAKE_POLICY_DEFAULT_CMP0048 NEW)
 
-project(primitiv VERSION 0.1.0 LANGUAGES CXX)
+project(primitiv VERSION 0.3.1 LANGUAGES CXX)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 option(PRIMITIV_BUILD_STATIC_LIBRARY "Builds static library." OFF)

--- a/primitiv/graph.cc
+++ b/primitiv/graph.cc
@@ -184,7 +184,7 @@ void Graph::backward(const Node &node) {
     cur_f.op->backward(*cur_v, cur_n.grad, arg_values, arg_grads);
 
     // Deletes current gradient to suppress memory.
-    cur_n.grad = Tensor();
+    cur_n.grad.invalidate();
   }
 }
 

--- a/primitiv/tensor.h
+++ b/primitiv/tensor.h
@@ -111,6 +111,17 @@ public:
   std::vector<std::uint32_t> argmin(std::uint32_t dim) const;
 
   /**
+   * Invalidates this object.
+   */
+  void invalidate() {
+    // NOTE(odashi):
+    // Not necessary to update `shape_` because it is never accessed anywhere.
+    //shape_ = Shape();
+    handle_.reset();
+    device_ = nullptr;
+  }
+
+  /**
    * Reset internal values using a constant.
    * @param k A value to be used to initialize each element.
    */

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -43,6 +43,15 @@ TEST_F(TensorTest, CheckInvalid) {
   EXPECT_THROW(x.to_vector(), Error);
 }
 
+TEST_F(TensorTest, CheckInvalidate) {
+  for (Device *dev : devices) {
+    Tensor x = dev->new_tensor_by_constant({}, 1);
+    ASSERT_TRUE(x.valid());
+    x.invalidate();
+    EXPECT_FALSE(x.valid());
+  }
+}
+
 TEST_F(TensorTest, CheckNewScalarWithData) {
   for (Device *dev : devices) {
     const Tensor x = dev->new_tensor_by_constant({}, 1);


### PR DESCRIPTION
This PR adds `Tensor::invalidate()` function which destroys inner pointer and invalidates the Tensor object. This function can be used instead of `tensor = Tensor()`.