### PR TITLE
Fix c api primitiv_Shape_dims.

### DIFF
--- a/primitiv/c/shape.cc
+++ b/primitiv/c/shape.cc
@@ -49,12 +49,14 @@ uint32_t safe_primitiv_Shape_op_getitem(const primitiv_Shape *shape,
   SAFE_RETURN(primitiv_Shape_op_getitem(shape, i), status, 0);
 }
 
-const uint32_t *primitiv_Shape_dims(const primitiv_Shape *shape) {
-  return &(to_cc(shape)->dims())[0];
+const void primitiv_Shape_dims(const primitiv_Shape *shape, uint32_t *array) {
+  std::vector<uint32_t> v = to_cc(shape)->dims();
+  std::copy(v.begin(), v.end(), array);
 }
-const uint32_t *safe_primitiv_Shape_dims(const primitiv_Shape *shape,
-                                         primitiv_Status *status) {
-  SAFE_RETURN(primitiv_Shape_dims(shape), status, 0);
+const void safe_primitiv_Shape_dims(const primitiv_Shape *shape,
+                                    uint32_t *array,
+                                    primitiv_Status *status) {
+  SAFE_EXPR(primitiv_Shape_dims(shape, array), status);
 }
 
 uint32_t primitiv_Shape_depth(const primitiv_Shape *shape) {

--- a/primitiv/c/shape.cc
+++ b/primitiv/c/shape.cc
@@ -49,13 +49,13 @@ uint32_t safe_primitiv_Shape_op_getitem(const primitiv_Shape *shape,
   SAFE_RETURN(primitiv_Shape_op_getitem(shape, i), status, 0);
 }
 
-const void primitiv_Shape_dims(const primitiv_Shape *shape, uint32_t *array) {
+void primitiv_Shape_dims(const primitiv_Shape *shape, uint32_t *array) {
   std::vector<uint32_t> v = to_cc(shape)->dims();
   std::copy(v.begin(), v.end(), array);
 }
-const void safe_primitiv_Shape_dims(const primitiv_Shape *shape,
-                                    uint32_t *array,
-                                    primitiv_Status *status) {
+void safe_primitiv_Shape_dims(const primitiv_Shape *shape,
+                              uint32_t *array,
+                              primitiv_Status *status) {
   SAFE_EXPR(primitiv_Shape_dims(shape, array), status);
 }
 

--- a/primitiv/c/shape.h
+++ b/primitiv/c/shape.h
@@ -31,10 +31,11 @@ CAPI extern uint32_t safe_primitiv_Shape_op_getitem(const primitiv_Shape *shape,
                                                     uint32_t i,
                                                     primitiv_Status *status);
 
-CAPI extern const void primitiv_Shape_dims(const primitiv_Shape *shape,
-                                           uint32_t *array);
-CAPI extern const void safe_primitiv_Shape_dims(
-    const primitiv_Shape *shape, uint32_t *array, primitiv_Status *status);
+CAPI extern void primitiv_Shape_dims(const primitiv_Shape *shape,
+                                     uint32_t *array);
+CAPI extern void safe_primitiv_Shape_dims(const primitiv_Shape *shape,
+                                          uint32_t *array,
+                                          primitiv_Status *status);
 
 CAPI extern uint32_t primitiv_Shape_depth(const primitiv_Shape *shape);
 CAPI extern uint32_t safe_primitiv_Shape_depth(const primitiv_Shape *shape,

--- a/primitiv/c/shape.h
+++ b/primitiv/c/shape.h
@@ -31,9 +31,10 @@ CAPI extern uint32_t safe_primitiv_Shape_op_getitem(const primitiv_Shape *shape,
                                                     uint32_t i,
                                                     primitiv_Status *status);
 
-CAPI extern const uint32_t *primitiv_Shape_dims(const primitiv_Shape *shape);
-CAPI extern const uint32_t *safe_primitiv_Shape_dims(
-    const primitiv_Shape *shape, primitiv_Status *status);
+CAPI extern const void primitiv_Shape_dims(const primitiv_Shape *shape,
+                                           uint32_t *array);
+CAPI extern const void safe_primitiv_Shape_dims(
+    const primitiv_Shape *shape, uint32_t *array, primitiv_Status *status);
 
 CAPI extern uint32_t primitiv_Shape_depth(const primitiv_Shape *shape);
 CAPI extern uint32_t safe_primitiv_Shape_depth(const primitiv_Shape *shape,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,3 +75,22 @@ endif()
 if(PRIMITIV_USE_OPENCL)
   primitiv_test(opencl_device)
 endif()
+
+if(PRIMITIV_BUILD_C_API)
+  function(primitiv_c_test name)
+    add_executable(c_${name}_test
+        test_utils.h c/${name}_test.cc $<TARGET_OBJECTS:test_utils_OBJS>)
+    if(PRIMITIV_GTEST_SOURCE_DIR)
+      add_dependencies(c_${name}_test GTest)
+    endif()
+    target_link_libraries(c_${name}_test primitiv_c
+        ${GTEST_BOTH_LIBRARIES} pthread)
+    add_test(
+        NAME c_${name}_test
+        COMMAND c_${name}_test
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  endfunction()
+
+  primitiv_c_test(shape)
+endif()

--- a/test/c/shape_test.cc
+++ b/test/c/shape_test.cc
@@ -15,56 +15,56 @@ class CShapeTest : public testing::Test {};
 
 TEST_F(CShapeTest, CheckNewDefault) {
   {
-    primitiv_Shape *shape = primitiv_Shape_new();
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 0));
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 1));
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 100));
+    ::primitiv_Shape *shape = ::primitiv_Shape_new();
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 0));
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 1));
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 100));
     std::uint32_t lhs[] = {};
-    std::uint32_t rhs[primitiv_Shape_depth(shape)];
-    primitiv_Shape_dims(shape, rhs);
+    std::uint32_t rhs[::primitiv_Shape_depth(shape)];
+    ::primitiv_Shape_dims(shape, rhs);
     EXPECT_TRUE(array_match(lhs, rhs, 0));
-    EXPECT_EQ(0u, primitiv_Shape_depth(shape));
-    EXPECT_EQ(1u, primitiv_Shape_batch(shape));
-    EXPECT_EQ(1u, primitiv_Shape_volume(shape));
-    EXPECT_EQ(1u, primitiv_Shape_size(shape));
-    primitiv_Shape_delete(shape);
+    EXPECT_EQ(0u, ::primitiv_Shape_depth(shape));
+    EXPECT_EQ(1u, ::primitiv_Shape_batch(shape));
+    EXPECT_EQ(1u, ::primitiv_Shape_volume(shape));
+    EXPECT_EQ(1u, ::primitiv_Shape_size(shape));
+    ::primitiv_Shape_delete(shape);
   }
 }
 
 TEST_F(CShapeTest, CheckNewByArray) {
   {
     std::uint32_t dims[] = {};
-    primitiv_Shape *shape = primitiv_Shape_new_with_dims(dims, 0, 1);
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 0));
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 1));
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 100));
+    ::primitiv_Shape *shape = ::primitiv_Shape_new_with_dims(dims, 0, 1);
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 0));
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 1));
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 100));
     std::uint32_t lhs[] = {};
-    std::uint32_t rhs[primitiv_Shape_depth(shape)];
-    primitiv_Shape_dims(shape, rhs);
+    std::uint32_t rhs[::primitiv_Shape_depth(shape)];
+    ::primitiv_Shape_dims(shape, rhs);
     EXPECT_TRUE(array_match(lhs, rhs, 0));
-    EXPECT_EQ(0u, primitiv_Shape_depth(shape));
-    EXPECT_EQ(1u, primitiv_Shape_batch(shape));
-    EXPECT_EQ(1u, primitiv_Shape_volume(shape));
-    EXPECT_EQ(1u, primitiv_Shape_size(shape));
-    primitiv_Shape_delete(shape);
+    EXPECT_EQ(0u, ::primitiv_Shape_depth(shape));
+    EXPECT_EQ(1u, ::primitiv_Shape_batch(shape));
+    EXPECT_EQ(1u, ::primitiv_Shape_volume(shape));
+    EXPECT_EQ(1u, ::primitiv_Shape_size(shape));
+    ::primitiv_Shape_delete(shape);
   }
   {
     std::uint32_t dims[] = {1, 2, 3};
-    primitiv_Shape *shape = primitiv_Shape_new_with_dims(dims, 3, 4);
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 0));
-    EXPECT_EQ(2u, primitiv_Shape_op_getitem(shape, 1));
-    EXPECT_EQ(3u, primitiv_Shape_op_getitem(shape, 2));
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 3));
-    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 100));
+    ::primitiv_Shape *shape = ::primitiv_Shape_new_with_dims(dims, 3, 4);
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 0));
+    EXPECT_EQ(2u, ::primitiv_Shape_op_getitem(shape, 1));
+    EXPECT_EQ(3u, ::primitiv_Shape_op_getitem(shape, 2));
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 3));
+    EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 100));
     std::uint32_t lhs[] = {1, 2, 3};
-    std::uint32_t rhs[primitiv_Shape_depth(shape)];
-    primitiv_Shape_dims(shape, rhs);
+    std::uint32_t rhs[::primitiv_Shape_depth(shape)];
+    ::primitiv_Shape_dims(shape, rhs);
     EXPECT_TRUE(array_match(lhs, rhs, 3));
-    EXPECT_EQ(3u, primitiv_Shape_depth(shape));
-    EXPECT_EQ(4u, primitiv_Shape_batch(shape));
-    EXPECT_EQ(6u, primitiv_Shape_volume(shape));
-    EXPECT_EQ(24u, primitiv_Shape_size(shape));
-    primitiv_Shape_delete(shape);
+    EXPECT_EQ(3u, ::primitiv_Shape_depth(shape));
+    EXPECT_EQ(4u, ::primitiv_Shape_batch(shape));
+    EXPECT_EQ(6u, ::primitiv_Shape_volume(shape));
+    EXPECT_EQ(24u, ::primitiv_Shape_size(shape));
+    ::primitiv_Shape_delete(shape);
   }
 }
 

--- a/test/c/shape_test.cc
+++ b/test/c/shape_test.cc
@@ -19,10 +19,6 @@ TEST_F(CShapeTest, CheckNewDefault) {
     EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 0));
     EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 1));
     EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 100));
-    std::uint32_t lhs[] = {};
-    std::uint32_t rhs[::primitiv_Shape_depth(shape)];
-    ::primitiv_Shape_dims(shape, rhs);
-    EXPECT_TRUE(array_match(lhs, rhs, 0));
     EXPECT_EQ(0u, ::primitiv_Shape_depth(shape));
     EXPECT_EQ(1u, ::primitiv_Shape_batch(shape));
     EXPECT_EQ(1u, ::primitiv_Shape_volume(shape));
@@ -38,10 +34,6 @@ TEST_F(CShapeTest, CheckNewByArray) {
     EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 0));
     EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 1));
     EXPECT_EQ(1u, ::primitiv_Shape_op_getitem(shape, 100));
-    std::uint32_t lhs[] = {};
-    std::uint32_t rhs[::primitiv_Shape_depth(shape)];
-    ::primitiv_Shape_dims(shape, rhs);
-    EXPECT_TRUE(array_match(lhs, rhs, 0));
     EXPECT_EQ(0u, ::primitiv_Shape_depth(shape));
     EXPECT_EQ(1u, ::primitiv_Shape_batch(shape));
     EXPECT_EQ(1u, ::primitiv_Shape_volume(shape));

--- a/test/c/shape_test.cc
+++ b/test/c/shape_test.cc
@@ -1,0 +1,71 @@
+#include <config.h>
+
+#include <utility>
+#include <vector>
+#include <gtest/gtest.h>
+#include <primitiv/c/shape.h>
+#include <test_utils.h>
+
+using std::vector;
+using test_utils::array_match;
+
+namespace primitiv {
+
+class CShapeTest : public testing::Test {};
+
+TEST_F(CShapeTest, CheckNewDefault) {
+  {
+    primitiv_Shape *shape = primitiv_Shape_new();
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 0));
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 1));
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 100));
+    std::uint32_t lhs[] = {};
+    std::uint32_t rhs[primitiv_Shape_depth(shape)];
+    primitiv_Shape_dims(shape, rhs);
+    EXPECT_TRUE(array_match(lhs, rhs, 0));
+    EXPECT_EQ(0u, primitiv_Shape_depth(shape));
+    EXPECT_EQ(1u, primitiv_Shape_batch(shape));
+    EXPECT_EQ(1u, primitiv_Shape_volume(shape));
+    EXPECT_EQ(1u, primitiv_Shape_size(shape));
+    primitiv_Shape_delete(shape);
+  }
+}
+
+TEST_F(CShapeTest, CheckNewByArray) {
+  {
+    std::uint32_t dims[] = {};
+    primitiv_Shape *shape = primitiv_Shape_new_with_dims(dims, 0, 1);
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 0));
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 1));
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 100));
+    std::uint32_t lhs[] = {};
+    std::uint32_t rhs[primitiv_Shape_depth(shape)];
+    primitiv_Shape_dims(shape, rhs);
+    EXPECT_TRUE(array_match(lhs, rhs, 0));
+    EXPECT_EQ(0u, primitiv_Shape_depth(shape));
+    EXPECT_EQ(1u, primitiv_Shape_batch(shape));
+    EXPECT_EQ(1u, primitiv_Shape_volume(shape));
+    EXPECT_EQ(1u, primitiv_Shape_size(shape));
+    primitiv_Shape_delete(shape);
+  }
+  {
+    std::uint32_t dims[] = {1, 2, 3};
+    primitiv_Shape *shape = primitiv_Shape_new_with_dims(dims, 3, 4);
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 0));
+    EXPECT_EQ(2u, primitiv_Shape_op_getitem(shape, 1));
+    EXPECT_EQ(3u, primitiv_Shape_op_getitem(shape, 2));
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 3));
+    EXPECT_EQ(1u, primitiv_Shape_op_getitem(shape, 100));
+    std::uint32_t lhs[] = {1, 2, 3};
+    std::uint32_t rhs[primitiv_Shape_depth(shape)];
+    primitiv_Shape_dims(shape, rhs);
+    EXPECT_TRUE(array_match(lhs, rhs, 3));
+    EXPECT_EQ(3u, primitiv_Shape_depth(shape));
+    EXPECT_EQ(4u, primitiv_Shape_batch(shape));
+    EXPECT_EQ(6u, primitiv_Shape_volume(shape));
+    EXPECT_EQ(24u, primitiv_Shape_size(shape));
+    primitiv_Shape_delete(shape);
+  }
+}
+
+}  // namespace primitiv

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -91,6 +91,54 @@ inline testing::AssertionResult vector_near(
   return testing::AssertionSuccess();
 }
 
+// helper to check array equality.
+template<typename T>
+inline testing::AssertionResult array_match(
+    const T expected[],
+    const T actual[],
+    size_t n) {
+  for (std::uint32_t i = 0; i < n; ++i) {
+    if (expected[i] != actual[i]) {
+      return testing::AssertionFailure()
+          << "expected[" << i << "]: " << expected[i]
+          << " != actual[" << i << "]: " << actual[i];
+    }
+  }
+  return testing::AssertionSuccess();
+}
+
+// helper to check float array equality.
+template<>
+inline testing::AssertionResult array_match(
+    const float expected[],
+    const float actual[],
+    size_t n) {
+  for (std::uint32_t i = 0; i < n; ++i) {
+    if (!test_utils::float_eq(expected[i], actual[i])) {
+      return testing::AssertionFailure()
+          << "expected[" << i << "]: " << expected[i]
+          << " != actual[" << i << "]: " << actual[i];
+    }
+  }
+  return testing::AssertionSuccess();
+}
+
+// helper to check closeness of float arrays.
+inline testing::AssertionResult array_near(
+    const float expected[],
+    const float actual[],
+    size_t n,
+    const float err) {
+  for (std::uint32_t i = 0; i < n; ++i) {
+    if (!test_utils::float_near(expected[i], actual[i], err)) {
+      return testing::AssertionFailure()
+          << "expected[" << i << "]: " << expected[i]
+          << " != actual[" << i << "]: " << actual[i];
+    }
+  }
+  return testing::AssertionSuccess();
+}
+
 // helper to generate std::string from a byte array.
 inline std::string bin_to_str(const std::initializer_list<int> data) {
   return std::string(data.begin(), data.end());


### PR DESCRIPTION
Reimplement primitiv_Shape_dims() not to return an invalid array pointer.