### PR TITLE
Enable Eigen on Travis CI

### DIFF
--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -7,7 +7,7 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td debian:stable /bi
 
 # install
 docker exec travis-ci bash -c "apt update"
-docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
+docker exec travis-ci bash -c "apt install -y build-essential cmake googletest libeigen3-dev"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"
@@ -19,7 +19,7 @@ docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
 docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 # script
-docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest/googletest"
+docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest/googletest"
 docker exec travis-ci bash -c "cd /primitiv && make VERBOSE=1"
 docker exec travis-ci bash -c "cd /primitiv && make test ARGS='-V'"
 docker exec travis-ci bash -c "cd /primitiv && make install"

--- a/.travis/fedora.sh
+++ b/.travis/fedora.sh
@@ -7,7 +7,7 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td fedora:latest /bi
 
 # install
 docker exec travis-ci bash -c "dnf update -y"
-docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel"
+docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel eigen3-devel"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "dnf install -y opencl-headers git hwloc-devel libtool-ltdl-devel ocl-icd-devel ocl-icd clang llvm-devel clang-devel zlib-devel blas-devel boost-devel patch --setopt=install_weak_deps=False"
@@ -22,7 +22,7 @@ docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
 docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 # script
-docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_TESTS=ON"
+docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_TESTS=ON"
 docker exec travis-ci bash -c "cd /primitiv && make VERBOSE=1"
 docker exec travis-ci bash -c "cd /primitiv && make test ARGS='-V'"
 docker exec travis-ci bash -c "cd /primitiv && make install"

--- a/.travis/fedora.sh
+++ b/.travis/fedora.sh
@@ -10,6 +10,15 @@ docker exec travis-ci bash -c "dnf update -y"
 docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel"
 
 # install Eigen
+#
+# NOTE(vbkaisetsu):
+# Fedora 27 contains Eigen 3.3.4 and gcc 7.2.1.
+# gcc/g++ 7 detects int-in-bool-context error in the latest released version of Eigen
+# by default, and it will be fixed in 3.3.5. For now, this script downloads the latest
+# development version to solve this problem.
+#
+# For more details, see: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1402
+#
 docker exec travis-ci bash -c "dnf install -y mercurial"
 docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
 docker exec travis-ci bash -c "mkdir ./eigen/build"

--- a/.travis/fedora.sh
+++ b/.travis/fedora.sh
@@ -7,7 +7,14 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td fedora:latest /bi
 
 # install
 docker exec travis-ci bash -c "dnf update -y"
-docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel eigen3-devel"
+docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel"
+
+# install Eigen
+docker exec travis-ci bash -c "dnf install -y mercurial"
+docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
+docker exec travis-ci bash -c "mkdir ./eigen/build"
+docker exec travis-ci bash -c "cd ./eigen/build && cmake .."
+docker exec travis-ci bash -c "cd ./eigen/build && make && make install"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "dnf install -y opencl-headers git hwloc-devel libtool-ltdl-devel ocl-icd-devel ocl-icd clang llvm-devel clang-devel zlib-devel blas-devel boost-devel patch --setopt=install_weak_deps=False"

--- a/.travis/osx.sh
+++ b/.travis/osx.sh
@@ -3,12 +3,13 @@ set -xe
 
 # install
 brew update
+brew install eigen
 git clone https://github.com/google/googletest.git $TRAVIS_BUILD_DIR/googletest
 
 # script
 export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH::$TRAVIS_BUILD_DIR/googletest/googletest/include
 cd $TRAVIS_BUILD_DIR
-cmake . -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=$TRAVIS_BUILD_DIR/googletest/googletest
+cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=$TRAVIS_BUILD_DIR/googletest/googletest
 make VERBOSE=1
 make test ARGS='-V'
 make install

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -7,7 +7,7 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td ubuntu:rolling /b
 
 # install
 docker exec travis-ci bash -c "apt update"
-docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
+docker exec travis-ci bash -c "apt install -y build-essential cmake googletest libeigen3-dev"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"
@@ -19,7 +19,7 @@ docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
 docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 # script
-docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest/googletest"
+docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest/googletest"
 docker exec travis-ci bash -c "cd /primitiv && make VERBOSE=1"
 docker exec travis-ci bash -c "cd /primitiv && make test ARGS='-V'"
 docker exec travis-ci bash -c "cd /primitiv && make install"

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -10,6 +10,15 @@ docker exec travis-ci bash -c "apt update"
 docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
 
 # install Eigen
+#
+# NOTE(vbkaisetsu):
+# Ubuntu 17.04  contains Eigen 3.3.4 and gcc 7.2.0.
+# gcc/g++ 7 detects int-in-bool-context error in the latest released version of Eigen
+# by default, and it will be fixed in 3.3.5. For now, this script downloads the latest
+# development version to solve this problem.
+#
+# For more details, see: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1402
+#
 docker exec travis-ci bash -c "apt install -y mercurial"
 docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
 docker exec travis-ci bash -c "mkdir ./eigen/build"

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -7,7 +7,14 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td ubuntu:rolling /b
 
 # install
 docker exec travis-ci bash -c "apt update"
-docker exec travis-ci bash -c "apt install -y build-essential cmake googletest libeigen3-dev"
+docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
+
+# install Eigen
+docker exec travis-ci bash -c "apt install -y mercurial"
+docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
+docker exec travis-ci bash -c "mkdir ./eigen/build"
+docker exec travis-ci bash -c "cd ./eigen/build && cmake .."
+docker exec travis-ci bash -c "cd ./eigen/build && make && make install"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"


### PR DESCRIPTION
This branch enables Eigen device on Travis CI.

It downloads the development version of Eigen in Ubuntu and Fedora to solve compatibility problem.