### PR TITLE
fix bug in test/optimizer_impl_test.cc

### DIFF
--- a/test/optimizer_impl_test.cc
+++ b/test/optimizer_impl_test.cc
@@ -115,7 +115,7 @@ TEST_F(OptimizerImplTest, CheckSGDSaveLoad) {
   std::remove(path.c_str());
 
   EXPECT_EQ(1, optimizer2.eta());
-  EXPECT_EQ(2, optimizer2.get_epoch());
+  EXPECT_EQ(2u, optimizer2.get_epoch());
   EXPECT_EQ(3, optimizer2.get_learning_rate_scaling());
   EXPECT_EQ(4, optimizer2.get_weight_decay());
   EXPECT_EQ(5, optimizer2.get_gradient_clipping());
@@ -135,7 +135,7 @@ TEST_F(OptimizerImplTest, CheckSGDGetConfigs) {
   EXPECT_EQ(1u, uint_configs.size());
   EXPECT_EQ(4u, float_configs.size());
   EXPECT_EQ(1, float_configs.at("SGD.eta"));
-  EXPECT_EQ(2, uint_configs.at("Optimizer.epoch"));
+  EXPECT_EQ(2u, uint_configs.at("Optimizer.epoch"));
   EXPECT_EQ(3, float_configs.at("Optimizer.lr_scale"));
   EXPECT_EQ(4, float_configs.at("Optimizer.l2_strength"));
   EXPECT_EQ(5, float_configs.at("Optimizer.clip_threshold"));
@@ -160,7 +160,7 @@ TEST_F(OptimizerImplTest, CheckSGDSetConfigs) {
   optimizer.set_configs(uint_configs, float_configs);
 
   EXPECT_EQ(1, optimizer.eta());
-  EXPECT_EQ(2, optimizer.get_epoch());
+  EXPECT_EQ(2u, optimizer.get_epoch());
   EXPECT_EQ(3, optimizer.get_learning_rate_scaling());
   EXPECT_EQ(4, optimizer.get_weight_decay());
   EXPECT_EQ(5, optimizer.get_gradient_clipping());
@@ -210,7 +210,7 @@ TEST_F(OptimizerImplTest, CheckMomentumSGDSaveLoad) {
 
   EXPECT_EQ(1, optimizer2.eta());
   EXPECT_EQ(2, optimizer2.momentum());
-  EXPECT_EQ(3, optimizer2.get_epoch());
+  EXPECT_EQ(3u, optimizer2.get_epoch());
   EXPECT_EQ(4, optimizer2.get_learning_rate_scaling());
   EXPECT_EQ(5, optimizer2.get_weight_decay());
   EXPECT_EQ(6, optimizer2.get_gradient_clipping());
@@ -231,7 +231,7 @@ TEST_F(OptimizerImplTest, CheckMomentumSGDGetConfigs) {
   EXPECT_EQ(5u, float_configs.size());
   EXPECT_EQ(1, float_configs.at("MomentumSGD.eta"));
   EXPECT_EQ(2, float_configs.at("MomentumSGD.momentum"));
-  EXPECT_EQ(3, uint_configs.at("Optimizer.epoch"));
+  EXPECT_EQ(3u, uint_configs.at("Optimizer.epoch"));
   EXPECT_EQ(4, float_configs.at("Optimizer.lr_scale"));
   EXPECT_EQ(5, float_configs.at("Optimizer.l2_strength"));
   EXPECT_EQ(6, float_configs.at("Optimizer.clip_threshold"));
@@ -258,7 +258,7 @@ TEST_F(OptimizerImplTest, CheckMomentumSGDSetConfigs) {
 
   EXPECT_EQ(1, optimizer.eta());
   EXPECT_EQ(2, optimizer.momentum());
-  EXPECT_EQ(3, optimizer.get_epoch());
+  EXPECT_EQ(3u, optimizer.get_epoch());
   EXPECT_EQ(4, optimizer.get_learning_rate_scaling());
   EXPECT_EQ(5, optimizer.get_weight_decay());
   EXPECT_EQ(6, optimizer.get_gradient_clipping());
@@ -320,7 +320,7 @@ TEST_F(OptimizerImplTest, CheckAdaGradSaveLoad) {
 
   EXPECT_EQ(1, optimizer2.eta());
   EXPECT_EQ(2, optimizer2.eps());
-  EXPECT_EQ(3, optimizer2.get_epoch());
+  EXPECT_EQ(3u, optimizer2.get_epoch());
   EXPECT_EQ(4, optimizer2.get_learning_rate_scaling());
   EXPECT_EQ(5, optimizer2.get_weight_decay());
   EXPECT_EQ(6, optimizer2.get_gradient_clipping());
@@ -341,7 +341,7 @@ TEST_F(OptimizerImplTest, CheckAdaGradGetConfigs) {
   EXPECT_EQ(5u, float_configs.size());
   EXPECT_EQ(1, float_configs.at("AdaGrad.eta"));
   EXPECT_EQ(2, float_configs.at("AdaGrad.eps"));
-  EXPECT_EQ(3, uint_configs.at("Optimizer.epoch"));
+  EXPECT_EQ(3u, uint_configs.at("Optimizer.epoch"));
   EXPECT_EQ(4, float_configs.at("Optimizer.lr_scale"));
   EXPECT_EQ(5, float_configs.at("Optimizer.l2_strength"));
   EXPECT_EQ(6, float_configs.at("Optimizer.clip_threshold"));
@@ -368,7 +368,7 @@ TEST_F(OptimizerImplTest, CheckAdaGradSetConfigs) {
 
   EXPECT_EQ(1, optimizer.eta());
   EXPECT_EQ(2, optimizer.eps());
-  EXPECT_EQ(3, optimizer.get_epoch());
+  EXPECT_EQ(3u, optimizer.get_epoch());
   EXPECT_EQ(4, optimizer.get_learning_rate_scaling());
   EXPECT_EQ(5, optimizer.get_weight_decay());
   EXPECT_EQ(6, optimizer.get_gradient_clipping());
@@ -431,7 +431,7 @@ TEST_F(OptimizerImplTest, CheckRMSPropSaveLoad) {
   EXPECT_EQ(1, optimizer2.eta());
   EXPECT_EQ(2, optimizer2.alpha());
   EXPECT_EQ(3, optimizer2.eps());
-  EXPECT_EQ(4, optimizer2.get_epoch());
+  EXPECT_EQ(4u, optimizer2.get_epoch());
   EXPECT_EQ(5, optimizer2.get_learning_rate_scaling());
   EXPECT_EQ(6, optimizer2.get_weight_decay());
   EXPECT_EQ(7, optimizer2.get_gradient_clipping());
@@ -453,7 +453,7 @@ TEST_F(OptimizerImplTest, CheckRMSPropGetConfigs) {
   EXPECT_EQ(1, float_configs.at("RMSProp.eta"));
   EXPECT_EQ(2, float_configs.at("RMSProp.alpha"));
   EXPECT_EQ(3, float_configs.at("RMSProp.eps"));
-  EXPECT_EQ(4, uint_configs.at("Optimizer.epoch"));
+  EXPECT_EQ(4u, uint_configs.at("Optimizer.epoch"));
   EXPECT_EQ(5, float_configs.at("Optimizer.lr_scale"));
   EXPECT_EQ(6, float_configs.at("Optimizer.l2_strength"));
   EXPECT_EQ(7, float_configs.at("Optimizer.clip_threshold"));
@@ -482,7 +482,7 @@ TEST_F(OptimizerImplTest, CheckRMSPropSetConfigs) {
   EXPECT_EQ(1, optimizer.eta());
   EXPECT_EQ(2, optimizer.alpha());
   EXPECT_EQ(3, optimizer.eps());
-  EXPECT_EQ(4, optimizer.get_epoch());
+  EXPECT_EQ(4u, optimizer.get_epoch());
   EXPECT_EQ(5, optimizer.get_learning_rate_scaling());
   EXPECT_EQ(6, optimizer.get_weight_decay());
   EXPECT_EQ(7, optimizer.get_gradient_clipping());
@@ -544,7 +544,7 @@ TEST_F(OptimizerImplTest, CheckAdaDeltaSaveLoad) {
 
   EXPECT_EQ(1, optimizer2.rho());
   EXPECT_EQ(2, optimizer2.eps());
-  EXPECT_EQ(3, optimizer2.get_epoch());
+  EXPECT_EQ(3u, optimizer2.get_epoch());
   EXPECT_EQ(4, optimizer2.get_learning_rate_scaling());
   EXPECT_EQ(5, optimizer2.get_weight_decay());
   EXPECT_EQ(6, optimizer2.get_gradient_clipping());
@@ -565,7 +565,7 @@ TEST_F(OptimizerImplTest, CheckAdaDeltaGetConfigs) {
   EXPECT_EQ(5u, float_configs.size());
   EXPECT_EQ(1, float_configs.at("AdaDelta.rho"));
   EXPECT_EQ(2, float_configs.at("AdaDelta.eps"));
-  EXPECT_EQ(3, uint_configs.at("Optimizer.epoch"));
+  EXPECT_EQ(3u, uint_configs.at("Optimizer.epoch"));
   EXPECT_EQ(4, float_configs.at("Optimizer.lr_scale"));
   EXPECT_EQ(5, float_configs.at("Optimizer.l2_strength"));
   EXPECT_EQ(6, float_configs.at("Optimizer.clip_threshold"));
@@ -592,7 +592,7 @@ TEST_F(OptimizerImplTest, CheckAdaDeltaSetConfigs) {
 
   EXPECT_EQ(1, optimizer.rho());
   EXPECT_EQ(2, optimizer.eps());
-  EXPECT_EQ(3, optimizer.get_epoch());
+  EXPECT_EQ(3u, optimizer.get_epoch());
   EXPECT_EQ(4, optimizer.get_learning_rate_scaling());
   EXPECT_EQ(5, optimizer.get_weight_decay());
   EXPECT_EQ(6, optimizer.get_gradient_clipping());
@@ -668,7 +668,7 @@ TEST_F(OptimizerImplTest, CheckAdamSaveLoad) {
   EXPECT_EQ(2, optimizer2.beta1());
   EXPECT_EQ(3, optimizer2.beta2());
   EXPECT_EQ(4, optimizer2.eps());
-  EXPECT_EQ(5, optimizer2.get_epoch());
+  EXPECT_EQ(5u, optimizer2.get_epoch());
   EXPECT_EQ(6, optimizer2.get_learning_rate_scaling());
   EXPECT_EQ(7, optimizer2.get_weight_decay());
   EXPECT_EQ(8, optimizer2.get_gradient_clipping());
@@ -691,7 +691,7 @@ TEST_F(OptimizerImplTest, CheckAdamGetConfigs) {
   EXPECT_EQ(2, float_configs.at("Adam.beta1"));
   EXPECT_EQ(3, float_configs.at("Adam.beta2"));
   EXPECT_EQ(4, float_configs.at("Adam.eps"));
-  EXPECT_EQ(5, uint_configs.at("Optimizer.epoch"));
+  EXPECT_EQ(5u, uint_configs.at("Optimizer.epoch"));
   EXPECT_EQ(6, float_configs.at("Optimizer.lr_scale"));
   EXPECT_EQ(7, float_configs.at("Optimizer.l2_strength"));
   EXPECT_EQ(8, float_configs.at("Optimizer.clip_threshold"));
@@ -722,7 +722,7 @@ TEST_F(OptimizerImplTest, CheckAdamSetConfigs) {
   EXPECT_EQ(2, optimizer.beta1());
   EXPECT_EQ(3, optimizer.beta2());
   EXPECT_EQ(4, optimizer.eps());
-  EXPECT_EQ(5, optimizer.get_epoch());
+  EXPECT_EQ(5u, optimizer.get_epoch());
   EXPECT_EQ(6, optimizer.get_learning_rate_scaling());
   EXPECT_EQ(7, optimizer.get_weight_decay());
   EXPECT_EQ(8, optimizer.get_gradient_clipping());


### PR DESCRIPTION
I fixed a bug in test/optimizer_impl_test.cc  
epoch in the optimizer is type int, but it should be uint.
