### PR TITLE
Add Travis script to build on Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 matrix:
   include:
     - os: linux
+      env: SCRIPT=ubuntu-vanilla
+      sudo: required
+    - os: linux
       env: SCRIPT=ubuntu
       services: docker
     - os: linux

--- a/.travis/ubuntu-vanilla.sh
+++ b/.travis/ubuntu-vanilla.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -xe
+
+# install
+sudo apt update
+sudo apt install -y build-essential cmake3 libgtest-dev libeigen3-dev
+
+# script
+cd $TRAVIS_BUILD_DIR
+cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/gtest
+make VERBOSE=1
+make test ARGS='-V'
+make install

--- a/.travis/ubuntu-vanilla.sh
+++ b/.travis/ubuntu-vanilla.sh
@@ -3,11 +3,25 @@ set -xe
 
 # install
 sudo apt update
-sudo apt install -y build-essential cmake3 libgtest-dev libeigen3-dev
+sudo apt install -y build-essential cmake3 libgtest-dev
+
+# install Eigen
+#
+# NOTE(vbkaisetsu):
+# Ubuntu 14.04 contains Eigen 3.2
+# primitiv requires 3.3 or later
+#
+wget http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 -O ./eigen.tar.bz2
+mkdir ./eigen
+tar xf ./eigen.tar.bz2 -C ./eigen --strip-components 1
+mkdir ./eigen/build
+cd ./eigen/build
+cmake ..
+make && sudo make install
 
 # script
 cd $TRAVIS_BUILD_DIR
 cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/gtest
 make VERBOSE=1
 make test ARGS='-V'
-make install
+sudo make install

--- a/.travis/ubuntu-vanilla.sh
+++ b/.travis/ubuntu-vanilla.sh
@@ -5,23 +5,19 @@ set -xe
 sudo apt update
 sudo apt install -y build-essential cmake3 libgtest-dev
 
-# install Eigen
+# download Eigen
 #
 # NOTE(vbkaisetsu):
 # Ubuntu 14.04 contains Eigen 3.2
 # primitiv requires 3.3 or later
 #
 wget http://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2 -O ./eigen.tar.bz2
-mkdir ./eigen
-tar xf ./eigen.tar.bz2 -C ./eigen --strip-components 1
-mkdir ./eigen/build
-cd ./eigen/build
-cmake ..
-make && sudo make install
+mkdir $TRAVIS_BUILD_DIR/eigen
+tar xf ./eigen.tar.bz2 -C $TRAVIS_BUILD_DIR/eigen --strip-components 1
 
 # script
 cd $TRAVIS_BUILD_DIR
-cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/gtest
+cmake . -DPRIMITIV_USE_EIGEN=ON -DEIGEN3_INCLUDE_DIR=$TRAVIS_BUILD_DIR/eigen -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/gtest
 make VERBOSE=1
 make test ARGS='-V'
 sudo make install


### PR DESCRIPTION
Related to #129

This branch add a travis script to build primitiv on Ubuntu 14.04 without Docker.