### PR TITLE
Add a flag to guarantee license

### DIFF
--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -7,7 +7,20 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td debian:stable /bi
 
 # install
 docker exec travis-ci bash -c "apt update"
-docker exec travis-ci bash -c "apt install -y build-essential cmake googletest libeigen3-dev"
+docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
+
+# TODO(vbkaisetsu):
+# Debian stretch contains Eigen 3.3.2. It has a bug around EIGEN_MPL2_ONLY
+# mode and SparseCholesky module. It is fixed in newer version.
+#
+# For more details, see: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1392
+
+# install Eigen
+docker exec travis-ci bash -c "apt install -y mercurial"
+docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
+docker exec travis-ci bash -c "mkdir ./eigen/build"
+docker exec travis-ci bash -c "cd ./eigen/build && cmake .."
+docker exec travis-ci bash -c "cd ./eigen/build && make && make install"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"

--- a/primitiv/eigen_device.cc
+++ b/primitiv/eigen_device.cc
@@ -13,6 +13,15 @@
 #include <cmath>
 #include <iostream>
 
+// NOTE(vbkaisetsu)
+// Eigen contains a few LGPL-licensed features. It will conflict with some
+// non-free licensed software that can link statically with Apache licensed
+// code.
+// EIGEN_MPL2_ONLY guarantees that primitiv does not use LGPL-licensed feature.
+//
+// For more ditails, see:
+// http://eigen.tuxfamily.org/index.php?title=Main_Page#License
+#define EIGEN_MPL2_ONLY
 #include <Eigen/Eigen>
 
 #include <primitiv/eigen_device.h>

--- a/primitiv/eigen_device.cc
+++ b/primitiv/eigen_device.cc
@@ -13,11 +13,11 @@
 #include <cmath>
 #include <iostream>
 
-// NOTE(vbkaisetsu)
-// Eigen contains a few LGPL-licensed features. It will conflict with some
-// non-free licensed software that can link statically with Apache licensed
-// code.
-// EIGEN_MPL2_ONLY guarantees that primitiv does not use LGPL-licensed feature.
+// NOTE(vbkaisetsu):
+// Eigen contains a few LGPL-licensed features. They conflict with
+// Apache License version 2.
+// EIGEN_MPL2_ONLY guarantees that primitiv does not use LGPL-licensed
+// features.
 //
 // For more ditails, see:
 // http://eigen.tuxfamily.org/index.php?title=Main_Page#License


### PR DESCRIPTION
This branch enables `EIGEN_MPL2_ONLY` flag that warns when primitiv uses LGPL licensed feature of Eigen.