### PR TITLE
Fix Shape::is_row_vector() to is_column_vector().

### DIFF
--- a/primitiv/shape.h
+++ b/primitiv/shape.h
@@ -15,7 +15,7 @@ namespace primitiv {
  * Examples:
  *   Shape()         == Shape({1, 1, 1, ...}, 1): scalar
  *   Shape({})       == Shape({1, 1, 1, ...}, 1): scalar
- *   Shape({n})      == Shape({n, 1, 1, ...}, 1): row vector
+ *   Shape({n})      == Shape({n, 1, 1, ...}, 1): column vector
  *   Shape({n, m})   == Shape({n, m, 1, ...}, 1): matrix
  *   Shape({...}, k): k-parallelized data (mini-batch)
  */
@@ -144,10 +144,10 @@ public:
   bool is_scalar() const { return depth() == 0; }
 
   /**
-   * Checks whether the shape is a row vector or not.
-   * @return true if the shape is a row vector, false otherwise.
+   * Checks whether the shape is a column vector or not.
+   * @return true if the shape is a column vector, false otherwise.
    */
-  bool is_row_vector() const { return depth() <= 1; }
+  bool is_column_vector() const { return depth() <= 1; }
 
   /**
    * Checks whether the shape is a vector or a matrix, or not.

--- a/test/shape_test.cc
+++ b/test/shape_test.cc
@@ -272,15 +272,15 @@ TEST_F(ShapeTest, CheckIsScalar) {
   EXPECT_FALSE(Shape({2, 3, 4}, 5).is_scalar());
 }
 
-TEST_F(ShapeTest, CheckIsRowVector) {
-  EXPECT_TRUE(Shape().is_row_vector());
-  EXPECT_TRUE(Shape({2}).is_row_vector());
-  EXPECT_FALSE(Shape({2, 3}).is_row_vector());
-  EXPECT_FALSE(Shape({2, 3, 4}).is_row_vector());
-  EXPECT_TRUE(Shape({}, 5).is_row_vector());
-  EXPECT_TRUE(Shape({2}, 5).is_row_vector());
-  EXPECT_FALSE(Shape({2, 3}, 5).is_row_vector());
-  EXPECT_FALSE(Shape({2, 3, 4}, 5).is_row_vector());
+TEST_F(ShapeTest, CheckIsColumnVector) {
+  EXPECT_TRUE(Shape().is_column_vector());
+  EXPECT_TRUE(Shape({2}).is_column_vector());
+  EXPECT_FALSE(Shape({2, 3}).is_column_vector());
+  EXPECT_FALSE(Shape({2, 3, 4}).is_column_vector());
+  EXPECT_TRUE(Shape({}, 5).is_column_vector());
+  EXPECT_TRUE(Shape({2}, 5).is_column_vector());
+  EXPECT_FALSE(Shape({2, 3}, 5).is_column_vector());
+  EXPECT_FALSE(Shape({2, 3, 4}, 5).is_column_vector());
 }
 
 TEST_F(ShapeTest, CheckIsMatrix) {


### PR DESCRIPTION
This pull request changes the interface `Shape::is_row_vector` to `Shape::is_column_vector` to adjust the name and the actual behavior.
All bindings in other languages should be fixed similarly.