### PR TITLE
Add max_pool2d function

### DIFF
--- a/primitiv/basic_functions.h
+++ b/primitiv/basic_functions.h
@@ -283,6 +283,13 @@ type_traits::Identity<Var> conv2d(
     std::uint32_t stride0, std::uint32_t stride1,
     std::uint32_t dilation0, std::uint32_t dilation1);
 
+template<typename Var>
+type_traits::Identity<Var> max_pool2d(
+    const Var &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1);
+
 namespace batch {
 
 template<typename Var>

--- a/primitiv/cuda_device.h
+++ b/primitiv/cuda_device.h
@@ -188,6 +188,22 @@ private:
       std::uint32_t dilation0, std::uint32_t dilation1,
       Tensor &gx, Tensor &gw) override;
 
+  void max_pool2d_fw_impl(
+      const Tensor &x,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &y) override
+  { THROW_NOT_IMPLEMENTED; }
+
+  void max_pool2d_bw_impl(
+      const Tensor &x, const Tensor &y, const Tensor &gy,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &gx) override
+  { THROW_NOT_IMPLEMENTED; }
+
   void inplace_multiply_const_impl(float k, Tensor &x) override;
 
   void inplace_add_impl(const Tensor &x, Tensor &y) override;

--- a/primitiv/cuda_device.h
+++ b/primitiv/cuda_device.h
@@ -193,16 +193,14 @@ private:
       std::uint32_t window0, std::uint32_t window1,
       std::uint32_t padding0, std::uint32_t padding1,
       std::uint32_t stride0, std::uint32_t stride1,
-      Tensor &y) override
-  { THROW_NOT_IMPLEMENTED; }
+      Tensor &y) override;
 
   void max_pool2d_bw_impl(
       const Tensor &x, const Tensor &y, const Tensor &gy,
       std::uint32_t window0, std::uint32_t window1,
       std::uint32_t padding0, std::uint32_t padding1,
       std::uint32_t stride0, std::uint32_t stride1,
-      Tensor &gx) override
-  { THROW_NOT_IMPLEMENTED; }
+      Tensor &gx) override;
 
   void inplace_multiply_const_impl(float k, Tensor &x) override;
 

--- a/primitiv/device.cc
+++ b/primitiv/device.cc
@@ -380,17 +380,30 @@ DEV_FW_AB(pow, shape_ops::elementwise);
 DEV_FW_AB(matmul, shape_ops::matmul);
 
 Tensor Device::conv2d_fw(
-    const Tensor &a, const Tensor &b,
+    const Tensor &x, const Tensor &w,
     std::uint32_t padding0, std::uint32_t padding1,
     std::uint32_t stride0, std::uint32_t stride1,
     std::uint32_t dilation0, std::uint32_t dilation1) {
-  CHECK_DEVICE(a);
-  CHECK_DEVICE(b);
+  CHECK_DEVICE(x);
+  CHECK_DEVICE(w);
   Tensor y = new_raw_tensor(shape_ops::conv2d(
-        a.shape(), b.shape(),
+        x.shape(), w.shape(),
         padding0, padding1, stride0, stride1, dilation0, dilation1));
   conv2d_fw_impl(
-      a, b, padding0, padding1, stride0, stride1, dilation0, dilation1, y);
+      x, w, padding0, padding1, stride0, stride1, dilation0, dilation1, y);
+  return y;
+}
+
+Tensor Device::max_pool2d_fw(
+    const Tensor &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1) {
+  CHECK_DEVICE(x);
+  Tensor y = new_raw_tensor(shape_ops::pool2d(
+        x.shape(), window0, window1, padding0, padding1, stride0, stride1));
+  max_pool2d_fw_impl(
+      x, window0, window1, padding0, padding1, stride0, stride1, y);
   return y;
 }
 
@@ -402,37 +415,72 @@ DEV_BW_AB(pow, shape_ops::elementwise);
 DEV_BW_AB(matmul, shape_ops::matmul);
 
 void Device::conv2d_bw(
-    const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
+    const Tensor &x, const Tensor &w, const Tensor &y, const Tensor &gy,
     std::uint32_t padding0, std::uint32_t padding1,
     std::uint32_t stride0, std::uint32_t stride1,
     std::uint32_t dilation0, std::uint32_t dilation1,
-    Tensor &ga, Tensor &gb) {
-  CHECK_DEVICE(a);
-  CHECK_DEVICE(b);
+    Tensor &gx, Tensor &gw) {
+  CHECK_DEVICE(x);
+  CHECK_DEVICE(w);
   CHECK_DEVICE(y);
   CHECK_DEVICE(gy);
-  CHECK_DEVICE(ga);
-  CHECK_DEVICE(gb);
-  if (a.shape() != ga.shape() ||
-      b.shape() != gb.shape() ||
+  CHECK_DEVICE(gx);
+  CHECK_DEVICE(gw);
+  if (x.shape() != gx.shape() ||
+      w.shape() != gw.shape() ||
       y.shape() != gy.shape() ||
       y.shape() != shape_ops::conv2d(
-        a.shape(), b.shape(),
+        x.shape(), w.shape(),
         padding0, padding1, stride0, stride1, dilation0, dilation1)) {
     THROW_ERROR(
         "Shape mismatched at conv2d_bw"
-        << ". a.shape: " << a.shape().to_string()
-        << ", b.shape: " << b.shape().to_string()
+        << ". x.shape: " << x.shape().to_string()
+        << ", w.shape: " << w.shape().to_string()
         << ", y.shape: " << y.shape().to_string()
         << ", gy.shape: " << gy.shape().to_string()
-        << ", ga.shape: " << ga.shape().to_string()
-        << ", gb.shape: " << gb.shape().to_string()
+        << ", gx.shape: " << gx.shape().to_string()
+        << ", gw.shape: " << gw.shape().to_string()
         << ", padding0: " << padding0
-        << ", padding1: " << padding1);
+        << ", padding1: " << padding1
+        << ", stride0: " << stride0
+        << ", stride1: " << stride1
+        << ", dilation0: " << dilation0
+        << ", dilation1: " << dilation1);
   }
   conv2d_bw_impl(
-      a, b, y, gy, padding0, padding1, stride0, stride1, dilation0, dilation1,
-      ga, gb);
+      x, w, y, gy, padding0, padding1, stride0, stride1, dilation0, dilation1,
+      gx, gw);
+}
+
+void Device::max_pool2d_bw(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1,
+    Tensor &gx) {
+  CHECK_DEVICE(x);
+  CHECK_DEVICE(y);
+  CHECK_DEVICE(gy);
+  CHECK_DEVICE(gx);
+  if (x.shape() != gx.shape() ||
+      y.shape() != gy.shape() ||
+      y.shape() != shape_ops::pool2d(
+        x.shape(), window0, window1, padding0, padding1, stride0, stride1)) {
+    THROW_ERROR(
+        "Shape mismatched at max_pool2d_bw"
+        << ". x.shape: " << x.shape().to_string()
+        << ", y.shape: " << y.shape().to_string()
+        << ", gy.shape: " << gy.shape().to_string()
+        << ", gx.shape: " << gx.shape().to_string()
+        << ", window0: " << window0
+        << ", window1: " << window1
+        << ", padding0: " << padding0
+        << ", padding1: " << padding1
+        << ", stride0: " << stride0
+        << ", stride1: " << stride1);
+  }
+  max_pool2d_bw_impl(
+      x, y, gy, window0, window1, padding0, padding1, stride0, stride1, gx);
 }
 
 #undef DEV_FW_X

--- a/primitiv/device.h
+++ b/primitiv/device.h
@@ -223,6 +223,20 @@ public:
       std::uint32_t dilation0, std::uint32_t dilation1,
       Tensor &gx, Tensor &gw);
 
+  // Pooling.
+  Tensor max_pool2d_fw(
+      const Tensor &x,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1);
+
+  void max_pool2d_bw(
+      const Tensor &x, const Tensor &y, const Tensor &gy,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &gx);
+
   /**
    * Directly multiplies all elements by a constant.
    * @param k A constant to multiply.
@@ -454,6 +468,20 @@ private:
       std::uint32_t stride0, std::uint32_t stride1,
       std::uint32_t dilation0, std::uint32_t dilation1,
       Tensor &gx, Tensor &gw) = 0;
+
+  virtual void max_pool2d_fw_impl(
+      const Tensor &x,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &y) = 0;
+
+  virtual void max_pool2d_bw_impl(
+      const Tensor &x, const Tensor &y, const Tensor &gy,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &gx) = 0;
 
   virtual void inplace_multiply_const_impl(float k, Tensor &x) = 0;
 

--- a/primitiv/eigen_device.h
+++ b/primitiv/eigen_device.h
@@ -158,6 +158,22 @@ private:
       Tensor &gx, Tensor &gw) override
   { THROW_NOT_IMPLEMENTED; }
 
+  void max_pool2d_fw_impl(
+      const Tensor &x,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &y) override
+  { THROW_NOT_IMPLEMENTED; }
+
+  void max_pool2d_bw_impl(
+      const Tensor &x, const Tensor &y, const Tensor &gy,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &gx) override
+  { THROW_NOT_IMPLEMENTED; }
+
   void inplace_multiply_const_impl(float k, Tensor &x) override;
 
   void inplace_add_impl(const Tensor &x, Tensor &y) override;

--- a/primitiv/error.h
+++ b/primitiv/error.h
@@ -53,5 +53,11 @@ public:
   throw primitiv::NotImplementedError(__FILE__, __LINE__, __func__); \
 }
 
+#define THROW_NOT_IMPLEMENTED_WITH_MESSAGE(cmds) { \
+  std::stringstream ss; \
+  ss << cmds; \
+  throw primitiv::NotImplementedError(__FILE__, __LINE__, ss.str()); \
+}
+
 
 #endif  // PRIMITIV_ERROR_H_

--- a/primitiv/naive_device.cc
+++ b/primitiv/naive_device.cc
@@ -841,6 +841,112 @@ void Naive::conv2d_bw_impl(
   }
 }
 
+void Naive::max_pool2d_fw_impl(
+    const Tensor &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1,
+    Tensor &y) {
+  const Shape x_shape = x.shape();
+  const Shape y_shape = y.shape();
+
+  const std::uint32_t x_height = x_shape[0];
+  const std::uint32_t x_width = x_shape[1];
+  const std::uint32_t y_height = y_shape[0];
+  const std::uint32_t y_width = y_shape[1];
+
+  const std::uint32_t repeat = x_shape.size() / (x_height * x_width);
+
+  const std::size_t x_shift = x_shape.volume();
+  const std::size_t y_shift = y_shape.volume();
+
+  const float *px = CDATA(x);
+  float *py = MDATA(y);
+
+  for (std::uint32_t r = 0; r < repeat; ++r) {
+    for (std::uint32_t y_x = 0; y_x < y_width; ++y_x) {
+      for (std::uint32_t y_y = 0; y_y < y_height; ++y_y) {
+        float maxval = std::numeric_limits<float>::lowest();
+
+        for (std::uint32_t w_x = 0; w_x < window1; ++w_x) {
+          const std::int32_t x_x = -padding1 + y_x * stride1 + w_x;
+          if (x_x < 0 || x_x >= static_cast<std::int32_t>(x_width)) continue;
+
+          for (std::uint32_t w_y = 0; w_y < window0; ++w_y) {
+            const std::int32_t x_y = -padding1 + y_y * stride1 + w_y;
+            if (x_y < 0 || x_y >= static_cast<std::int32_t>(x_height)) continue;
+
+            const float val = px[x_x * x_height + x_y];
+            if (val > maxval) maxval = val;
+          }
+        }
+
+        py[y_x * y_height + y_y] = maxval;
+      }
+    }
+
+    px += x_shift;
+    py += y_shift;
+  }
+}
+
+void Naive::max_pool2d_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1,
+    Tensor &gx) {
+  const Shape x_shape = x.shape();
+  const Shape y_shape = y.shape();
+
+  const std::uint32_t x_height = x_shape[0];
+  const std::uint32_t x_width = x_shape[1];
+  const std::uint32_t y_height = y_shape[0];
+  const std::uint32_t y_width = y_shape[1];
+
+  const std::uint32_t repeat = x_shape.size() / (x_height * x_width);
+
+  const std::size_t x_shift = x_shape.volume();
+  const std::size_t y_shift = y_shape.volume();
+
+  const float *px = CDATA(x);
+  const float *py = CDATA(y);
+  const float *pgy = CDATA(gy);
+  float *pgx = MDATA(gx);
+
+  for (std::uint32_t r = 0; r < repeat; ++r) {
+    for (std::uint32_t y_x = 0; y_x < y_width; ++y_x) {
+      for (std::uint32_t y_y = 0; y_y < y_height; ++y_y) {
+        const std::uint32_t y_addr = y_x * y_height + y_y;
+        const float maxval = py[y_addr];
+        const float grad = pgy[y_addr];
+        bool next = true;
+
+        for (std::uint32_t w_x = 0; next && w_x < window1; ++w_x) {
+          const std::int32_t x_x = -padding1 + y_x * stride1 + w_x;
+          if (x_x < 0 || x_x >= static_cast<std::int32_t>(x_width)) continue;
+
+          for (std::uint32_t w_y = 0; next && w_y < window0; ++w_y) {
+            const std::int32_t x_y = -padding1 + y_y * stride1 + w_y;
+            if (x_y < 0 || x_y >= static_cast<std::int32_t>(x_height)) continue;
+
+            const std::uint32_t x_addr = x_x * x_height + x_y;
+            if (px[x_addr] == maxval) {
+              pgx[x_addr] += grad;
+              next = false;
+            }
+          }
+        }
+      }
+    }
+
+    px += x_shift;
+    py += y_shift;
+    pgy += y_shift;
+    pgx += x_shift;
+  }
+}
+
 void Naive::inplace_multiply_const_impl(float k, Tensor &x) {
   const std::uint32_t size = x.shape().size();
   float *dest = MDATA(x);

--- a/primitiv/naive_device.cc
+++ b/primitiv/naive_device.cc
@@ -855,10 +855,10 @@ void Naive::max_pool2d_fw_impl(
   const std::uint32_t y_height = y_shape[0];
   const std::uint32_t y_width = y_shape[1];
 
-  const std::uint32_t repeat = x_shape.size() / (x_height * x_width);
+  const std::size_t x_shift = x_height * x_width;
+  const std::size_t y_shift = y_height * y_width;
 
-  const std::size_t x_shift = x_shape.volume();
-  const std::size_t y_shift = y_shape.volume();
+  const std::uint32_t repeat = x_shape.size() / x_shift;
 
   const float *px = CDATA(x);
   float *py = MDATA(y);
@@ -873,7 +873,7 @@ void Naive::max_pool2d_fw_impl(
           if (x_x < 0 || x_x >= static_cast<std::int32_t>(x_width)) continue;
 
           for (std::uint32_t w_y = 0; w_y < window0; ++w_y) {
-            const std::int32_t x_y = -padding1 + y_y * stride1 + w_y;
+            const std::int32_t x_y = -padding0 + y_y * stride0 + w_y;
             if (x_y < 0 || x_y >= static_cast<std::int32_t>(x_height)) continue;
 
             const float val = px[x_x * x_height + x_y];
@@ -904,10 +904,10 @@ void Naive::max_pool2d_bw_impl(
   const std::uint32_t y_height = y_shape[0];
   const std::uint32_t y_width = y_shape[1];
 
-  const std::uint32_t repeat = x_shape.size() / (x_height * x_width);
+  const std::size_t x_shift = x_height * x_width;
+  const std::size_t y_shift = y_height * y_width;
 
-  const std::size_t x_shift = x_shape.volume();
-  const std::size_t y_shift = y_shape.volume();
+  const std::uint32_t repeat = x_shape.size() / x_shift;
 
   const float *px = CDATA(x);
   const float *py = CDATA(y);
@@ -927,7 +927,7 @@ void Naive::max_pool2d_bw_impl(
           if (x_x < 0 || x_x >= static_cast<std::int32_t>(x_width)) continue;
 
           for (std::uint32_t w_y = 0; next && w_y < window0; ++w_y) {
-            const std::int32_t x_y = -padding1 + y_y * stride1 + w_y;
+            const std::int32_t x_y = -padding0 + y_y * stride0 + w_y;
             if (x_y < 0 || x_y >= static_cast<std::int32_t>(x_height)) continue;
 
             const std::uint32_t x_addr = x_x * x_height + x_y;

--- a/primitiv/naive_device.h
+++ b/primitiv/naive_device.h
@@ -156,6 +156,22 @@ private:
       std::uint32_t dilation0, std::uint32_t dilation1,
       Tensor &gx, Tensor &gw) override;
 
+  void max_pool2d_fw_impl(
+      const Tensor &x,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &y) override
+  { THROW_NOT_IMPLEMENTED; }
+
+  void max_pool2d_bw_impl(
+      const Tensor &x, const Tensor &y, const Tensor &gy,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &gx) override
+  { THROW_NOT_IMPLEMENTED; }
+
   void inplace_multiply_const_impl(float k, Tensor &x) override;
 
   void inplace_add_impl(const Tensor &x, Tensor &y) override;

--- a/primitiv/naive_device.h
+++ b/primitiv/naive_device.h
@@ -161,16 +161,14 @@ private:
       std::uint32_t window0, std::uint32_t window1,
       std::uint32_t padding0, std::uint32_t padding1,
       std::uint32_t stride0, std::uint32_t stride1,
-      Tensor &y) override
-  { THROW_NOT_IMPLEMENTED; }
+      Tensor &y) override;
 
   void max_pool2d_bw_impl(
       const Tensor &x, const Tensor &y, const Tensor &gy,
       std::uint32_t window0, std::uint32_t window1,
       std::uint32_t padding0, std::uint32_t padding1,
       std::uint32_t stride0, std::uint32_t stride1,
-      Tensor &gx) override
-  { THROW_NOT_IMPLEMENTED; }
+      Tensor &gx) override;
 
   void inplace_multiply_const_impl(float k, Tensor &x) override;
 

--- a/primitiv/node_funcs.cc
+++ b/primitiv/node_funcs.cc
@@ -288,6 +288,18 @@ Node conv2d(
       x, w);
 }
 
+template<>
+Node max_pool2d(
+    const Node &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1) {
+  return REGX(
+      x,
+      MaxPooling2D(window0, window1, padding0, padding1, stride0, stride1),
+      x);
+}
+
 namespace batch {
 
 template<>

--- a/primitiv/opencl_device.h
+++ b/primitiv/opencl_device.h
@@ -202,6 +202,22 @@ private:
       Tensor &gx, Tensor &gw) override
   { THROW_NOT_IMPLEMENTED; }
 
+  void max_pool2d_fw_impl(
+      const Tensor &x,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &y) override
+  { THROW_NOT_IMPLEMENTED; }
+
+  void max_pool2d_bw_impl(
+      const Tensor &x, const Tensor &y, const Tensor &gy,
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1,
+      Tensor &gx) override
+  { THROW_NOT_IMPLEMENTED; }
+
   void inplace_multiply_const_impl(float k, Tensor &x) override;
 
   void inplace_add_impl(const Tensor &x, Tensor &y) override;

--- a/primitiv/operator_impl.cc
+++ b/primitiv/operator_impl.cc
@@ -336,6 +336,12 @@ Shape Convolution2D::forward_shape(const vector<const Shape *> &args) const {
       padding0_, padding1_, stride0_, stride1_, dilation0_, dilation1_);
 }
 
+Shape MaxPooling2D::forward_shape(const vector<const Shape *> &args) const {
+  CHECK_ARGNUM(args, 1);
+  return shape_ops::pool2d(
+      *args[0], window0_, window1_, padding0_, padding1_, stride0_, stride1_);
+}
+
 Shape SoftmaxCrossEntropy::forward_shape(
     const vector<const Shape *> &args) const {
   CHECK_ARGNUM(args, 2);
@@ -417,6 +423,11 @@ FORWARD(Convolution2D) {
   return functions::conv2d(
       *x[0], *x[1],
       padding0_, padding1_, stride0_, stride1_, dilation0_, dilation1_);
+}
+
+FORWARD(MaxPooling2D) {
+  return functions::max_pool2d(
+      *x[0], window0_, window1_, padding0_, padding1_, stride0_, stride1_);
 }
 
 FORWARD(SoftmaxCrossEntropy) {
@@ -534,6 +545,13 @@ BACKWARD(Convolution2D) {
       *x[0], *x[1], y, gy,
       padding0_, padding1_, stride0_, stride1_, dilation0_, dilation1_,
       *gx[0], *gx[1]);
+}
+
+BACKWARD(MaxPooling2D) {
+  gy.device().max_pool2d_bw(
+      *x[0], y, gy,
+      window0_, window1_, padding0_, padding1_, stride0_, stride1_,
+      *gx[0]);
 }
 
 BACKWARD(SoftmaxCrossEntropy) {

--- a/primitiv/operator_impl.h
+++ b/primitiv/operator_impl.h
@@ -385,6 +385,34 @@ private:
   std::uint32_t dilation0_, dilation1_;
 };
 
+class MaxPooling2D : public Operator {
+  NO_CTOR_CLASS_DECL(MaxPooling2D);
+
+public:
+  MaxPooling2D(
+      std::uint32_t window0, std::uint32_t window1,
+      std::uint32_t padding0, std::uint32_t padding1,
+      std::uint32_t stride0, std::uint32_t stride1)
+  : window0_(window0), window1_(window1)
+  , padding0_(padding0), padding1_(padding1)
+  , stride0_(stride0), stride1_(stride1) {}
+
+  std::string name() const override {
+    return "MaxPooling2D("
+      + string_utils::to_string(window0_) + ","
+      + string_utils::to_string(window1_) + ","
+      + string_utils::to_string(padding0_) + ","
+      + string_utils::to_string(padding1_) + ","
+      + string_utils::to_string(stride0_) + ","
+      + string_utils::to_string(stride1_) + ")";
+  }
+
+private:
+  std::uint32_t window0_, window1_;
+  std::uint32_t padding0_, padding1_;
+  std::uint32_t stride0_, stride1_;
+};
+
 #undef DECL_OPERATOR
 #undef DECL_OPERATOR_K
 #undef NO_CTOR_CLASS_DECL

--- a/primitiv/shape_ops.cc
+++ b/primitiv/shape_ops.cc
@@ -147,15 +147,40 @@ Shape conv2d(
       stride0 == 0 || stride1 == 0 ||
       dilation0 == 0 || dilation1 == 0) {
     THROW_ERROR(
-        "Invalid arguments to calculate the convolution: "
+        "Invalid arguments to calculate a convolution: "
         << x.to_string() << ", " << w.to_string() << ", "
         << padding0 << ", " << padding1 << ", "
         << stride0 << ", " << stride1 << ", "
-        << dilation0 << ", " << dilation1 << ", ");
+        << dilation0 << ", " << dilation1);
   }
   return Shape(
       {(x0 - w0) / stride0 + 1, (x1 - w1) / stride1 + 1, w[3]},
       std::max(x.batch(), w.batch()));
+}
+
+Shape pool2d(
+    const Shape &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1) {
+  const std::uint32_t x0 = x[0] + 2 * padding0;
+  const std::uint32_t x1 = x[1] + 2 * padding1;
+
+  if (x.depth() > 3 ||
+      x0 < window0 || x1 < window1 ||
+      window0 == 0 || window1 == 0 ||
+      stride0 == 0 || stride1 == 0) {
+    THROW_ERROR(
+        "Invalid arguments to calculate a pooling: "
+        << x.to_string() << ", "
+        << window0 << ", " << window1 << ", "
+        << padding0 << ", " << padding1 << ", "
+        << stride0 << ", " << stride1);
+  }
+
+  return Shape(
+      {(x0 - window0) / stride0 + 1, (x1 - window1) / stride1 + 1, x[2]},
+      x.batch());
 }
 
 }  // namespace shape_ops

--- a/primitiv/shape_ops.h
+++ b/primitiv/shape_ops.h
@@ -12,94 +12,94 @@ namespace shape_ops {
  * Modifies the shape with keeping the number of elements.
  * @param before Source shape.
  * @param after Target shape.
- * @return A shape with dims of `after` and batch size of `before`.
+ * @return Calculated shape with dims of `after` and batch size of `before`.
  */
 Shape reshape(const Shape &before, const Shape &after);
 
 /**
- * Calculates the flattened shape.
+ * Calculates a flattened shape.
  * @param x A shape.
  * @return Flattened shape.
  */
 Shape flatten(const Shape &x);
 
 /**
- * Calculates the shape after the scalar operation.
+ * Calculates a shape after the scalar operation.
  * @param x A shape.
  * @param k A scalar shape.
- * @return A shape, that is equivalent to `(x + k).shape()`.
+ * @return Calculated shape, that is equivalent to `(x + k).shape()`.
  * @remarks `k` should be a scalar: `Shape({}, batch_size)`.
  */
 Shape scalar_op(const Shape &x, const Shape &k);
 
 /**
- * Calculates the shape after the elementwise operation.
+ * Calculates a shape after the elementwise operation.
  * @param a A shape.
  * @param b Other shape.
- * @return A shape, that is equivalent to `(a + b).shape()`.
+ * @return Calculated shape, that is equivalent to `(a + b).shape()`.
  */
 Shape elementwise(const Shape &a, const Shape &b);
 
 /**
- * Calculates the shape of the slice.
+ * Calculates a shape of the slice.
  * @param x A shape.
  * @param dim Dimension to slice.
  * @param lower Lower bound of the dimension `dim`.
  * @param upper Lower bound of the dimension `dim`.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape slice(const Shape &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper);
 
 /**
- * Calculates the concatenated shape.
+ * Calculates a concatenated shape.
  * @param xs A list of shapes.
  * @param dim Dimension to be concatenated.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape concat(const std::vector<Shape> &xs, std::uint32_t dim);
 
 /**
- * Calculates the concatenated shape.
+ * Calculates a concatenated shape.
  * @param xs A list of shapes.
  * @param dim Dimension to be concatenated.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape concat(const std::vector<const Shape *> &xs, std::uint32_t dim);
 
 /**
- * Calculates the broadcasted shape.
+ * Calculates a broadcasted shape.
  * @param x A shape.
  * @param dim Dimension to broadcast.
  * @param size New size of the dimension `dim`.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape broadcast(const Shape &x, std::uint32_t dim, std::uint32_t size);
 
 /**
- * Calculates the picked shape.
+ * Calculates a picked shape.
  * @param x A shape.
  * @param ids Label IDs to be picked from the dimension `dim`.
  * @param dim Dimension to pick.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape pick(const Shape &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim);
 
 /**
- * Calculates the transposed shape.
+ * Calculates a transposed shape.
  * @param x A shape.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape transpose(const Shape &x);
 
-/** Calculates the shape of matrix products.
+/** Calculates a shape of matrix products.
  * @param l Shape of the left hand side.
  * @param r Shape of the right hand side.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape matmul(const Shape &l, const Shape &r);
 
 /**
- * Calculates the resulting shape of convolution.
+ * Calculates a resulting shape of convolution.
  * @param x Shape of the input tensor.
  * @param w Shape of the filter tensor.
  * @param padding0 Zero-padding width of the first dimension.
@@ -108,13 +108,30 @@ Shape matmul(const Shape &l, const Shape &r);
  * @param stride1 Stride of the second dimension.
  * @param dilation0 Upscaling factor of the first dimension.
  * @param dilation1 Upscaling factor of the second dimension.
- * @return A shape.
+ * @return Calculated shape.
  */
 Shape conv2d(
     const Shape &x, const Shape &w,
     std::uint32_t padding0, std::uint32_t padding1,
     std::uint32_t stride0, std::uint32_t stride1,
     std::uint32_t dilation0, std::uint32_t dilation1);
+
+/**
+ * Calculates a resulting shape of 2-dimensional pooling operations.
+ * @param x Input shape.
+ * @param window0 Window width of the first dimension.
+ * @param window1 Window width of the second dimension.
+ * @param padding0 Padding width of the first dimension.
+ * @param padding1 Padding width of the second dimension.
+ * @param stride0 Stride of the first dimension.
+ * @param stride1 Stride of the second dimension.
+ * @return Calculated shape.
+ */
+Shape pool2d(
+    const Shape &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1);
 
 }  // namespace shape_ops
 }  // namespace primitiv

--- a/primitiv/tensor_funcs.cc
+++ b/primitiv/tensor_funcs.cc
@@ -296,6 +296,16 @@ Tensor conv2d(
       x, w, padding0, padding1, stride0, stride1, dilation0, dilation1);
 }
 
+template<>
+Tensor max_pool2d(
+    const Tensor &x,
+    std::uint32_t window0, std::uint32_t window1,
+    std::uint32_t padding0, std::uint32_t padding1,
+    std::uint32_t stride0, std::uint32_t stride1) {
+  return x.device().max_pool2d_fw(
+      x, window0, window1, padding0, padding1, stride0, stride1);
+}
+
 namespace batch {
 
 template<>

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -2777,38 +2777,34 @@ TEST_F(TensorForwardTest, CheckInvalidConv2D) {
     // invalid #dimensions
     {{1, 1, 1, 2}, {}, 0, 0, 1, 1, 1, 1, false},
     {{}, {1, 1, 1, 1, 2}, 0, 0, 1, 1, 1, 1, false},
-
     // zero-stride/dilation
+    {{}, {}, 0, 0, 1, 1, 1, 1, true},
     {{}, {}, 0, 0, 0, 1, 1, 1, false},
     {{}, {}, 0, 0, 1, 0, 1, 1, false},
     {{}, {}, 0, 0, 1, 1, 0, 1, false},
     {{}, {}, 0, 0, 1, 1, 1, 0, false},
-
     // minibatches mismatching
+    {Shape({}, 2), Shape({}, 2), 0, 0, 1, 1, 1, 1, true},
+    {Shape({}, 3), Shape({}, 3), 0, 0, 1, 1, 1, 1, true},
     {Shape({}, 2), Shape({}, 3), 0, 0, 1, 1, 1, 1, false},
-
     // channels mismatching
     {{3, 3, 42}, {3, 3, 42}, 0, 0, 1, 1, 1, 1, true},
     {{3, 3, 42}, {3, 3, 43}, 0, 0, 1, 1, 1, 1, false},
-
     // sizes mismatching
     {{3, 3}, {3, 3}, 0, 0, 1, 1, 1, 1, true},
     {{3, 3}, {4, 3}, 0, 0, 1, 1, 1, 1, false},
     {{3, 3}, {3, 4}, 0, 0, 1, 1, 1, 1, false},
     {{3, 3}, {4, 4}, 0, 0, 1, 1, 1, 1, false},
-
     // sizes mismatching with padding
     {{3, 3}, {5, 5}, 1, 1, 1, 1, 1, 1, true},
     {{3, 3}, {6, 5}, 1, 1, 1, 1, 1, 1, false},
     {{3, 3}, {5, 6}, 1, 1, 1, 1, 1, 1, false},
     {{3, 3}, {6, 6}, 1, 1, 1, 1, 1, 1, false},
-
     // sizes mismatching with stride
     {{3, 3}, {3, 3}, 0, 0, 2, 2, 1, 1, true},
     {{3, 3}, {4, 3}, 0, 0, 2, 2, 1, 1, false},
     {{3, 3}, {3, 4}, 0, 0, 2, 2, 1, 1, false},
     {{3, 3}, {4, 4}, 0, 0, 2, 2, 1, 1, false},
-
     // sizes mismatching with dilation
     {{3, 3}, {2, 2}, 0, 0, 1, 1, 2, 2, true},
     {{2, 3}, {2, 2}, 0, 0, 1, 1, 2, 2, false},

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -3112,17 +3112,17 @@ TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Stride22) {
 TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_N) {
   const vector<float> x_data = make_iota_vector(5 * 5 * 3, 1);
   const vector<float> y_data {
-    // channel 1
+    // minibatch 1
      7,  8,  9, 10,
     12, 13, 14, 15,
     17, 18, 19, 20,
     22, 23, 24, 25,
-    // channel 2
+    // minibatch 2
     32, 33, 34, 35,
     37, 38, 39, 40,
     42, 43, 44, 45,
     47, 48, 49, 50,
-    // channel 3
+    // minibatch 3
     57, 58, 59, 60,
     62, 63, 64, 65,
     67, 68, 69, 70,
@@ -3131,6 +3131,26 @@ TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_N) {
   const Shape x_shape({5, 5}, 3);
   const Shape y_shape({4, 4}, 3);
   TEST_MAX_POOL2D(2, 2, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_VGG16ThirdLayer) {
+  // NOTE(odashi): 224*224*64 < 2^23 (float precision)
+  const vector<float> x_data = make_iota_vector(224 * 224 * 64, 1);
+  vector<float> y_data(112 * 112 * 64);
+  for (unsigned b = 0; b < 64; ++b) {
+    float *py = y_data.data() + b * 112 * 112;
+    const unsigned b_ofs = b * 224 * 224;
+    for (unsigned x = 0; x < 112; ++x) {
+      float *py2 = py + x * 112;
+      const unsigned x_ofs = b_ofs + (2 * x + 1) * 224;
+      for (unsigned y = 0; y < 112; ++y) {
+        py2[y] = x_ofs + 2 * y + 2;
+      }
+    }
+  }
+  const Shape x_shape {224, 224, 64};
+  const Shape y_shape {112, 112, 64};
+  TEST_MAX_POOL2D(2, 2, 0, 0, 2, 2);
 }
 
 #undef TEST_MAX_POOL2D

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -2834,6 +2834,7 @@ TEST_F(TensorForwardTest, CheckInvalidConv2D) {
 
 #define TEST_MAX_POOL2D(win0, win1, pad0, pad1, str0, str1) { \
   for (Device *dev : devices) try { \
+    std::cout << dev << std::endl; \
     const Tensor x = dev->new_tensor_by_vector(x_shape, x_data); \
     const Tensor y = max_pool2d(x, win0, win1, pad0, pad1, str0, str1); \
     EXPECT_EQ(y_shape, y.shape()); \
@@ -2845,9 +2846,291 @@ TEST_F(TensorForwardTest, CheckMaxPool2D_1x1x1_1x1) {
   const vector<float> x_data {123};
   const vector<float> y_data {123};
   const Shape x_shape {};
-  const Shape w_shape {};
   const Shape y_shape {};
   TEST_MAX_POOL2D(1, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x1x1_1x1) {
+  const vector<float> x_data = make_iota_vector(5, 1);
+  const vector<float> y_data {1, 2, 3, 4, 5};
+  const Shape x_shape {5};
+  const Shape y_shape {5};
+  TEST_MAX_POOL2D(1, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x1x1_2x1) {
+  const vector<float> x_data = make_iota_vector(5, 1);
+  const vector<float> y_data {2, 3, 4, 5};
+  const Shape x_shape {5};
+  const Shape y_shape {4};
+  TEST_MAX_POOL2D(2, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x1x1_5x1) {
+  const vector<float> x_data = make_iota_vector(5, 1);
+  const vector<float> y_data {5};
+  const Shape x_shape {5};
+  const Shape y_shape {};
+  TEST_MAX_POOL2D(5, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_1x5x1_1x1) {
+  const vector<float> x_data = make_iota_vector(5, 1);
+  const vector<float> y_data {1, 2, 3, 4, 5};
+  const Shape x_shape {1, 5};
+  const Shape y_shape {1, 5};
+  TEST_MAX_POOL2D(1, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_1x5x1_1x2) {
+  const vector<float> x_data = make_iota_vector(5, 1);
+  const vector<float> y_data {2, 3, 4, 5};
+  const Shape x_shape {1, 5};
+  const Shape y_shape {1, 4};
+  TEST_MAX_POOL2D(1, 2, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_1x5x1_1x5) {
+  const vector<float> x_data = make_iota_vector(5, 1);
+  const vector<float> y_data {5};
+  const Shape x_shape {1, 5};
+  const Shape y_shape {};
+  TEST_MAX_POOL2D(1, 5, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_1x1) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     1,  2,  3,  4,  5,
+     6,  7,  8,  9, 10,
+    11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {5, 5};
+  TEST_MAX_POOL2D(1, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x1) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     2,  3,  4,  5,
+     7,  8,  9, 10,
+    12, 13, 14, 15,
+    17, 18, 19, 20,
+    22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {4, 5};
+  TEST_MAX_POOL2D(2, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_5x1) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     5,
+    10,
+    15,
+    20,
+    25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {1, 5};
+  TEST_MAX_POOL2D(5, 1, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_1x2) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     6,  7,  8,  9, 10,
+    11, 12, 13, 14, 15,
+    16, 17, 18, 19, 20,
+    21, 22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {5, 4};
+  TEST_MAX_POOL2D(1, 2, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     7,  8,  9, 10,
+    12, 13, 14, 15,
+    17, 18, 19, 20,
+    22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {4, 4};
+  TEST_MAX_POOL2D(2, 2, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_5x2) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+    10,
+    15,
+    20,
+    25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {1, 4};
+  TEST_MAX_POOL2D(5, 2, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_1x5) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+    21, 22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {5};
+  TEST_MAX_POOL2D(1, 5, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x5) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+    22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {4};
+  TEST_MAX_POOL2D(2, 5, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_5x5) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {25};
+  const Shape x_shape {5, 5};
+  const Shape y_shape {};
+  TEST_MAX_POOL2D(5, 5, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x3_2x2) {
+  const vector<float> x_data = make_iota_vector(5 * 5 * 3, 1);
+  const vector<float> y_data {
+    // channel 1
+     7,  8,  9, 10,
+    12, 13, 14, 15,
+    17, 18, 19, 20,
+    22, 23, 24, 25,
+    // channel 2
+    32, 33, 34, 35,
+    37, 38, 39, 40,
+    42, 43, 44, 45,
+    47, 48, 49, 50,
+    // channel 3
+    57, 58, 59, 60,
+    62, 63, 64, 65,
+    67, 68, 69, 70,
+    72, 73, 74, 75,
+  };
+  const Shape x_shape {5, 5, 3};
+  const Shape y_shape {4, 4, 3};
+  TEST_MAX_POOL2D(2, 2, 0, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Padding10) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     6,  7,  8,  9, 10, 10,
+    11, 12, 13, 14, 15, 15,
+    16, 17, 18, 19, 20, 20,
+    21, 22, 23, 24, 25, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {6, 4};
+  TEST_MAX_POOL2D(2, 2, 1, 0, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Padding01) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     2,  3,  4,  5,
+     7,  8,  9, 10,
+    12, 13, 14, 15,
+    17, 18, 19, 20,
+    22, 23, 24, 25,
+    22, 23, 24, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {4, 6};
+  TEST_MAX_POOL2D(2, 2, 0, 1, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Padding11) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     1,  2,  3,  4,  5,  5,
+     6,  7,  8,  9, 10, 10,
+    11, 12, 13, 14, 15, 15,
+    16, 17, 18, 19, 20, 20,
+    21, 22, 23, 24, 25, 25,
+    21, 22, 23, 24, 25, 25,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {6, 6};
+  TEST_MAX_POOL2D(2, 2, 1, 1, 1, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Stride21) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     7,  9,
+    12, 14,
+    17, 19,
+    22, 24,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {2, 4};
+  TEST_MAX_POOL2D(2, 2, 0, 0, 2, 1);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Stride12) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     7,  8,  9, 10,
+    17, 18, 19, 20,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {4, 2};
+  TEST_MAX_POOL2D(2, 2, 0, 0, 1, 2);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_Stride22) {
+  const vector<float> x_data = make_iota_vector(5 * 5, 1);
+  const vector<float> y_data {
+     7,  9,
+    17, 19,
+  };
+  const Shape x_shape {5, 5};
+  const Shape y_shape {2, 2};
+  TEST_MAX_POOL2D(2, 2, 0, 0, 2, 2);
+}
+
+TEST_F(TensorForwardTest, CheckMaxPool2D_5x5x1_2x2_N) {
+  const vector<float> x_data = make_iota_vector(5 * 5 * 3, 1);
+  const vector<float> y_data {
+    // channel 1
+     7,  8,  9, 10,
+    12, 13, 14, 15,
+    17, 18, 19, 20,
+    22, 23, 24, 25,
+    // channel 2
+    32, 33, 34, 35,
+    37, 38, 39, 40,
+    42, 43, 44, 45,
+    47, 48, 49, 50,
+    // channel 3
+    57, 58, 59, 60,
+    62, 63, 64, 65,
+    67, 68, 69, 70,
+    72, 73, 74, 75,
+  };
+  const Shape x_shape({5, 5}, 3);
+  const Shape y_shape({4, 4}, 3);
+  TEST_MAX_POOL2D(2, 2, 0, 0, 1, 1);
 }
 
 #undef TEST_MAX_POOL2D


### PR DESCRIPTION
This branch adds `max_pool2d` basic function.

- Usage:

```c++
// Using `Node` instead of `Tensor` is also allowed.
Tensor input = functions::input(Shape({128, 128, 3}, 64), ...);
Tensor output = functions::max_pool2d(
    input,
    2, 2,  // window sizes (1st-dim, 2nd-dim)
    0, 0,  // paddings (1st-dim, 2nd-dim)
    2, 2);  // strides (1st-dim, 2nd-dim)
// `output` is of Shape({64, 64, 3}, 64)
```

- Input is of `Shape({i_height, i_width, channels}, minibatch)`
- Output is of `Shape({o_height, o_width, channels}, minibatch)`
- Swapping `*_height` and `*_width` is also allowed.

`o_height/width` are calculated as:
- `o_height = (i_height + 2 * padding - window) / stride + 1`
- `o_width = (i_width + 2 * padding - window) / stride + 1`

Related issues: #35.