### PR TITLE
Add XavierUniformConv2D and XavierNormalConv2D initializers.

### DIFF
--- a/primitiv/initializer_impl.cc
+++ b/primitiv/initializer_impl.cc
@@ -50,5 +50,31 @@ void XavierNormal::apply(Tensor &x) const {
   x = x.device().random_normal(s, 0, sd);
 }
 
+void XavierUniformConv2D::apply(Tensor &x) const {
+  const Shape s = x.shape();
+  if (s.depth() > 4) {
+    THROW_ERROR(
+        "XavierUniformConv2D initializer can be used to only tensors with "
+        "up to 4 dimensions.");
+  }
+  const std::uint32_t fan_in = s[0] * s[1] * s[2];
+  const std::uint32_t fan_out = s[0] * s[1] * s[3];
+  const float bound = scale_ * std::sqrt(6. / (fan_in + fan_out));
+  x = x.device().random_uniform(s, -bound, bound);
+}
+
+void XavierNormalConv2D::apply(Tensor &x) const {
+  const Shape s = x.shape();
+  if (s.depth() > 4) {
+    THROW_ERROR(
+        "XavierNormalConv2D initializer can be used to only tensors with "
+        "up to 4 dimensions.");
+  }
+  const std::uint32_t fan_in = s[0] * s[1] * s[2];
+  const std::uint32_t fan_out = s[0] * s[1] * s[3];
+  const float sd = scale_ * std::sqrt(2. / (fan_in + fan_out));
+  x = x.device().random_normal(s, 0, sd);
+}
+
 }  // namespace initializers
 }  // namespace primitiv

--- a/primitiv/initializer_impl.h
+++ b/primitiv/initializer_impl.h
@@ -89,6 +89,32 @@ private:
   float scale_;
 };
 
+/**
+ * The Xavier initialization with the uniform distribution for conv2d filters.
+ */
+class XavierUniformConv2D : public Initializer {
+public:
+  XavierUniformConv2D(float scale = 1.0f) : scale_(scale) {}
+
+  void apply(Tensor &x) const override;
+
+private:
+  float scale_;
+};
+
+/**
+ * The Xavier initialization with the normal distribution for conv2d filters.
+ */
+class XavierNormalConv2D : public Initializer {
+public:
+  XavierNormalConv2D(float scale = 1.0f) : scale_(scale) {}
+
+  void apply(Tensor &x) const override;
+
+private:
+  float scale_;
+};
+
 }  // namespace initializers
 }  // namespace primitiv
 

--- a/test/initializer_impl_test.cc
+++ b/test/initializer_impl_test.cc
@@ -114,12 +114,15 @@ TEST_F(InitializerImplTest, CheckInvalidIdentity) {
 }
 
 TEST_F(InitializerImplTest, CheckXavierUniform) {
-  const std::uint32_t N = 768;
-  const std::uint32_t fan_in = N;
-  const std::uint32_t fan_out = N;
-  const std::uint32_t num_params = N * N;
+  const std::uint32_t H = 768;
+  const std::uint32_t W = 768;
+  const std::uint32_t fan_in = H;
+  const std::uint32_t fan_out = W;
+#ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
+  const std::uint32_t num_params = H * W;
+#endif  // PRIMITIV_BUILD_TESTS_PROBABILISTIC
 
-  Tensor x = dev.new_tensor_by_constant({fan_in, fan_out}, 0);
+  Tensor x = dev.new_tensor_by_constant({H, W}, 0);
 
   for (float scale : {.5f, 1.f, 2.f}) {
     const float bound = scale * std::sqrt(6. / (fan_in + fan_out));
@@ -155,12 +158,15 @@ TEST_F(InitializerImplTest, CheckInvalidXavierUniform) {
 
 TEST_F(InitializerImplTest, CheckXavierNormal) {
   // NOTE(odashi): This test checks only mean and SD.
-  const std::uint32_t N = 768;
-  const std::uint32_t fan_in = N;
-  const std::uint32_t fan_out = N;
-  const std::uint32_t num_params = N * N;
+  const std::uint32_t H = 768;
+  const std::uint32_t W = 768;
+#ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
+  const std::uint32_t fan_in = H;
+  const std::uint32_t fan_out = W;
+  const std::uint32_t num_params = H * W;
+#endif  // PRIMITIV_BUILD_TESTS_PROBABILISTIC
 
-  Tensor x = dev.new_tensor_by_constant({fan_in, fan_out}, 0);
+  Tensor x = dev.new_tensor_by_constant({H, W}, 0);
 
   for (float scale : {.5f, 1.f, 2.f}) {
     const XavierNormal init(scale);
@@ -197,7 +203,9 @@ TEST_F(InitializerImplTest, CheckXavierUniformConv2D) {
   const std::uint32_t K = 32;
   const std::uint32_t fan_in = H * W * C;
   const std::uint32_t fan_out = H * W * K;
+#ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
   const std::uint32_t num_params = H * W * C * K;
+#endif  // PRIMITIV_BUILD_TESTS_PROBABILISTIC
 
   Tensor x = dev.new_tensor_by_constant({H, W, C, K}, 0);
 
@@ -239,9 +247,11 @@ TEST_F(InitializerImplTest, CheckXavierNormalConv2D) {
   const std::uint32_t W = 32;
   const std::uint32_t C = 32;
   const std::uint32_t K = 32;
+#ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
   const std::uint32_t fan_in = H * W * C;
   const std::uint32_t fan_out = H * W * K;
   const std::uint32_t num_params = H * W * C * K;
+#endif  // PRIMITIV_BUILD_TESTS_PROBABILISTIC
 
   Tensor x = dev.new_tensor_by_constant({H, W, C, K}, 0);
 


### PR DESCRIPTION
This branch adds two Xavier initializers for conv2d filters.
- `XavierUniformConv2D`: uses a uniform distribution scaled by `sqrt(6/(fan_in + fan_out))`
- `XavierNormalConv2D`: uses a normal distribution scaled by `sqrt(2/(fan_in + fan_out))`

where:
- `fan_in = shape[0] * shape[1] * shape[2]`
- `fan_out = shape[0] * shape[1] * shape[3]`

Related issues: #35.