### PR TITLE
Add include stddef.h directive for size_t.

### DIFF
--- a/primitiv/c/define.h
+++ b/primitiv/c/define.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_C_DEFINE_H_
 #define PRIMITIV_C_DEFINE_H_
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
This pull request adds `#include <stddef.h>` directive to `c/define.h `for `size_t`.
Without stddef.h, rust-bindgen (that uses clang) cannot generate bindings because `size_t` is unknown.