### PR TITLE
Add "PRIMITIV_" prefix to macros.

### DIFF
--- a/primitiv/CMakeLists.txt
+++ b/primitiv/CMakeLists.txt
@@ -133,8 +133,10 @@ endif()
 
 # Build rules of the CUDA backend.
 if(PRIMITIV_USE_CUDA)
-  set(primitiv_cuda_HDRS cuda_device.h cuda16_device.h cuda_utils.h)
-  set(primitiv_cuda_SRCS cuda_device.cu cuda16_device.cu cuda_utils.cu)
+  set(primitiv_cuda_HDRS cuda_device.h cuda16_device.h)
+  set(primitiv_cuda_SRCS cuda_device.cu cuda16_device.cu)
+  set(primitiv_cuda_internal_HDRS internal/cuda_utils.h)
+  set(primitiv_cuda_internal_SRCS internal/cuda_utils.cu)
   file(GLOB primitiv_cuda_devops_HDRS "device_ops/cuda/*.h")
   file(GLOB primitiv_cuda_devops_SRCS "device_ops/cuda/*.cu")
   file(GLOB primitiv_cuda16_devops_HDRS "device_ops/cuda16/*.h")
@@ -173,6 +175,8 @@ if(PRIMITIV_USE_CUDA)
     ${primitiv_core_HDRS}
     ${primitiv_cuda_HDRS}
     ${primitiv_cuda_SRCS}
+    ${primitiv_cuda_internal_HDRS}
+    ${primitiv_cuda_internal_SRCS}
     ${primitiv_cuda_devops_HDRS}
     ${primitiv_cuda_devops_SRCS}
     ${primitiv_cuda16_devops_HDRS}

--- a/primitiv/c/internal.h
+++ b/primitiv/c/internal.h
@@ -47,7 +47,7 @@ catch (const std::exception &e) { \
 
 #define PRIMITIV_C_CHECK_NOT_NULL(var) \
 if (!var) { \
-  THROW_ERROR("Argument `" #var "` must not be null."); \
+  PRIMITIV_THROW_ERROR("Argument `" #var "` must not be null."); \
 }
 
 struct primitivDevice;
@@ -115,7 +115,7 @@ inline void copy_vector_to_array(
     const std::vector<T> &vector, T *array, std::size_t *size) {
   if (array) {
     if (*size < vector.size()) {
-      THROW_ERROR("Size is not enough to copy a vector.");
+      PRIMITIV_THROW_ERROR("Size is not enough to copy a vector.");
     }
     std::copy(vector.begin(), vector.end(), array);
   } else {
@@ -127,7 +127,7 @@ inline void copy_string_to_array(
     const std::string &str, char *buffer, std::size_t *size) {
   if (buffer) {
     if (*size <= str.length()) {
-      THROW_ERROR("Size is not enough to copy a string.");
+      PRIMITIV_THROW_ERROR("Size is not enough to copy a string.");
     }
     std::strcpy(buffer, str.c_str());
   } else {

--- a/primitiv/composite_functions.h
+++ b/primitiv/composite_functions.h
@@ -40,7 +40,7 @@ inline type_traits::Identity<Var> selu(
 template<typename Container>
 inline type_traits::Reduce<Container> sum(const Container &xs) {
   using Var = type_traits::Reduce<Container>;
-  if (xs.empty()) THROW_ERROR("No nodes to sum.");
+  if (xs.empty()) PRIMITIV_THROW_ERROR("No nodes to sum.");
   auto it = xs.begin();
   Var ret = *it++;
   while (it != xs.end()) ret = ret + *it++;
@@ -58,7 +58,7 @@ inline type_traits::Reduce<Container> sum(const Container &xs) {
 template<typename Container>
 inline type_traits::ReducePtr<Container> sum(const Container &xs) {
   using Var = type_traits::ReducePtr<Container>;
-  if (xs.empty()) THROW_ERROR("No nodes to sum.");
+  if (xs.empty()) PRIMITIV_THROW_ERROR("No nodes to sum.");
   auto it = xs.begin();
   Var ret = **it++;
   while (it != xs.end()) ret = ret + **it++;

--- a/primitiv/cuda16_device.cu
+++ b/primitiv/cuda16_device.cu
@@ -3,7 +3,7 @@
 #include <random>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/error.h>
 
 namespace {
@@ -27,7 +27,7 @@ std::uint32_t CUDA16::num_devices() {
 
 void CUDA16::assert_support(std::uint32_t device_id) {
   if (device_id >= num_devices()) {
-    THROW_ERROR("Invalid device ID: " << device_id);
+    PRIMITIV_THROW_ERROR("Invalid device ID: " << device_id);
   }
 
   ::cudaDeviceProp prop;
@@ -43,7 +43,7 @@ void CUDA16::assert_support(std::uint32_t device_id) {
   constexpr std::uint32_t MIN_CC = ::get_capability(MIN_CC_MAJOR, MIN_CC_MINOR);
   const std::uint32_t dev_cc = ::get_capability(prop.major, prop.minor);
   if (dev_cc < MIN_CC) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "CUDA Device " << device_id << " does not satisfy the "
         "minimum requirement of the compute capability: "
         << prop.major << '.' << prop.minor << " < "
@@ -55,7 +55,7 @@ void CUDA16::assert_support(std::uint32_t device_id) {
 #define CHECK_REQUIREMENT(name, value) \
   { \
     if (prop.name < (value)) { \
-      THROW_ERROR( \
+      PRIMITIV_THROW_ERROR( \
           "CUDA Device " << device_id \
           << " does not satisfy the minimum requirement by primitiv. " \
           << "property: " << #name << ", " \
@@ -66,7 +66,7 @@ void CUDA16::assert_support(std::uint32_t device_id) {
 #define CHECK_REQUIREMENT_VECTOR(name, index, value) \
   { \
     if (prop.name[index] < (value)) { \
-      THROW_ERROR( \
+      PRIMITIV_THROW_ERROR( \
           "CUDA16 Device " << device_id \
           << " does not satisfy the minimum requirement by primitiv. " \
           << "property: " << #name << "[" << #index << "], " \

--- a/primitiv/cuda_device.cu
+++ b/primitiv/cuda_device.cu
@@ -3,7 +3,7 @@
 #include <random>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/error.h>
 
 namespace primitiv {
@@ -17,7 +17,7 @@ std::uint32_t CUDA::num_devices() {
 
 void CUDA::assert_support(std::uint32_t device_id) {
   if (device_id >= num_devices()) {
-    THROW_ERROR("Invalid device ID: " << device_id);
+    PRIMITIV_THROW_ERROR("Invalid device ID: " << device_id);
   }
 
   ::cudaDeviceProp prop;
@@ -28,7 +28,7 @@ void CUDA::assert_support(std::uint32_t device_id) {
   static const int MIN_CC_MINOR = 0;
   if (prop.major < MIN_CC_MAJOR ||
       (prop.major == MIN_CC_MAJOR && prop.minor < MIN_CC_MINOR)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "CUDA Device " << device_id << " does not satisfy the "
         "minimum requirement of the compute capability: "
         << prop.major << '.' << prop.minor << " < "
@@ -39,7 +39,7 @@ void CUDA::assert_support(std::uint32_t device_id) {
 #define CHECK_REQUIREMENT(name, value) \
   { \
     if (prop.name < (value)) { \
-      THROW_ERROR( \
+      PRIMITIV_THROW_ERROR( \
           "CUDA Device " << device_id \
           << " does not satisfy the minimum requirement by primitiv. " \
           << "property: " << #name << ", " \
@@ -50,7 +50,7 @@ void CUDA::assert_support(std::uint32_t device_id) {
 #define CHECK_REQUIREMENT_VECTOR(name, index, value) \
   { \
     if (prop.name[index] < (value)) { \
-      THROW_ERROR( \
+      PRIMITIV_THROW_ERROR( \
           "CUDA Device " << device_id \
           << " does not satisfy the minimum requirement by primitiv. " \
           << "property: " << #name << "[" << #index << "], " \

--- a/primitiv/device.cc
+++ b/primitiv/device.cc
@@ -10,7 +10,7 @@ using std::vector;
 
 #define CHECK_DEVICE(x) \
   if (&(x).device() != this) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "Device mismatched. &(" #x ").device(): " << &(x).device() \
         << " != this: " << this); \
   }
@@ -70,7 +70,7 @@ void Device::reset_tensor_by_array(const float values[], Tensor &x) {
 void Device::reset_tensor_by_vector(const vector<float> &values, Tensor &x) {
   CHECK_DEVICE(x);
   if (values.size() != x.shape().size()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Data sizes mismatched. required: " << x.shape().size()
         << " (shape: " << x.shape().to_string() << ") != actual: "
         << values.size());
@@ -81,7 +81,7 @@ void Device::reset_tensor_by_vector(const vector<float> &values, Tensor &x) {
 Tensor Device::copy_tensor(const Tensor &x) {
   // NOTE(odashi):
   // This function should return always different memory with x.
-  if (!x.valid()) THROW_ERROR("Attempted to copy an invalid tensor.");
+  if (!x.valid()) PRIMITIV_THROW_ERROR("Attempted to copy an invalid tensor.");
   Tensor y = new_raw_tensor(x.shape());
   copy_tensor_impl(x, y);
   return y;
@@ -89,7 +89,7 @@ Tensor Device::copy_tensor(const Tensor &x) {
 
 Tensor Device::identity(std::uint32_t size) {
   if (size == 0) {
-    THROW_ERROR("Invalid size of the identity matrix: " << size);
+    PRIMITIV_THROW_ERROR("Invalid size of the identity matrix: " << size);
   }
   Tensor y = new_raw_tensor({size, size});
   identity_impl(y);
@@ -98,7 +98,7 @@ Tensor Device::identity(std::uint32_t size) {
 
 Tensor Device::random_bernoulli(const Shape &shape, float p) {
   if (p < 0 || p > 1) {
-    THROW_ERROR("Invalid Bernoulli probability: " << p);
+    PRIMITIV_THROW_ERROR("Invalid Bernoulli probability: " << p);
   }
   Tensor y = new_raw_tensor(shape);
   random_bernoulli_impl(p, y);
@@ -108,7 +108,7 @@ Tensor Device::random_bernoulli(const Shape &shape, float p) {
 Tensor Device::random_uniform(
     const Shape &shape, float lower, float upper) {
   if (upper < lower) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid parameter of the uniform distribution. lower: " << lower
         << ", upper: " << upper);
   }
@@ -119,7 +119,7 @@ Tensor Device::random_uniform(
 
 Tensor Device::random_normal(const Shape &shape, float mean, float sd) {
   if (sd <= 0) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid parameter of the normal distribution. mean: " << mean
         << ", SD: " << sd);
   }
@@ -130,7 +130,7 @@ Tensor Device::random_normal(const Shape &shape, float mean, float sd) {
 
 Tensor Device::random_log_normal(const Shape &shape, float mean, float sd) {
   if (sd <= 0) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid parameter of the log-normal distribution. mean: " << mean
         << ", SD: " << sd);
   }
@@ -157,7 +157,7 @@ Tensor Device::slice_fw(
 }
 
 Tensor Device::concat_fw(const vector<const Tensor *> &xs, std::uint32_t dim) {
-  if (xs.empty()) THROW_ERROR("No tensors to concat.");
+  if (xs.empty()) PRIMITIV_THROW_ERROR("No tensors to concat.");
   vector<Shape> shapes;
   shapes.reserve(xs.size());
 
@@ -178,7 +178,7 @@ void Device::pick_bw(
   CHECK_DEVICE(gx);
   const Shape sy = shape_ops::pick(gx.shape(), ids, dim);
   if (gy.shape() != sy) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched. gy.shape(): " << gy.shape().to_string()
         << " != expected shape: " << sy.to_string());
   }
@@ -193,7 +193,7 @@ void Device::slice_bw(
   const Shape &sx = gx.shape();
   if (!sy.has_same_loo_dims(sx, dim) || !sy.has_compatible_batch(sx) ||
       offset + sy[dim] > sx[dim]) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Attempted to add gradients with shape "
         << sy.to_string() << ", dim " << dim << ", offset " << offset
         << " to shape" << sx.to_string() << '.');
@@ -220,7 +220,7 @@ void Device::name##_bw( \
   if (x.shape() != gx.shape() || \
       y.shape() != gy.shape() || \
       y.shape() != sop(x.shape())) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "Shape mismatched at " #name "_bw" \
         << ". x.shape: " << x.shape().to_string() \
         << ", y.shape: " << y.shape().to_string() \
@@ -247,7 +247,7 @@ void Device::name##_bw( \
   CHECK_DEVICE(gx); \
   const Shape &s = x.shape(); \
   if (y.shape() != s || gy.shape() != s || gx.shape() != s) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "Shape mismatched at " #name "_bw" \
         << ". x.shape: " << s.to_string() \
         << ", y.shape: " << y.shape().to_string() \
@@ -280,7 +280,7 @@ void Device::name##_bw( \
       b.shape() != gb.shape() || \
       y.shape() != gy.shape() || \
       y.shape() != sop(a.shape(), b.shape())) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "Shape mismatched at " #name "_bw" \
         << ". a.shape: " << a.shape().to_string() \
         << ", b.shape: " << b.shape().to_string() \
@@ -353,7 +353,7 @@ void Device::pown_bw(
   CHECK_DEVICE(gx);
   const Shape &s = x.shape();
   if (y.shape() != s || gy.shape() != s || gx.shape() != s) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched at pown_bw"
         << ". x.shape: " << s.to_string()
         << ", y.shape: " << y.shape().to_string()
@@ -432,7 +432,7 @@ void Device::conv2d_bw(
       y.shape() != shape_ops::conv2d(
         x.shape(), w.shape(),
         padding0, padding1, stride0, stride1, dilation0, dilation1)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched at conv2d_bw"
         << ". x.shape: " << x.shape().to_string()
         << ", w.shape: " << w.shape().to_string()
@@ -466,7 +466,7 @@ void Device::max_pool2d_bw(
       y.shape() != gy.shape() ||
       y.shape() != shape_ops::pool2d(
         x.shape(), window0, window1, padding0, padding1, stride0, stride1)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched at max_pool2d_bw"
         << ". x.shape: " << x.shape().to_string()
         << ", y.shape: " << y.shape().to_string()
@@ -530,7 +530,7 @@ void Device::inplace_add(const Tensor &x, Tensor &y) {
   const Shape &sx = x.shape();
   const Shape &sy = y.shape();
   if (!sx.has_same_dims(sy) || !sx.has_compatible_batch(sy)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Attempted to add values of shape "
         << sx.to_string() << " to " << sy.to_string() << '.');
   }
@@ -543,7 +543,7 @@ void Device::inplace_subtract(const Tensor &x, Tensor &y) {
   const Shape &sx = x.shape();
   const Shape &sy = y.shape();
   if (!sx.has_same_dims(sy) || !sx.has_compatible_batch(sy)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Attempted to subtract values of shape "
         << sx.to_string() << " from " << sy.to_string() << '.');
   }

--- a/primitiv/device_ops/cuda/add.cu
+++ b/primitiv/device_ops/cuda/add.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/argmax.cu
+++ b/primitiv/device_ops/cuda/argmax.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/argmin.cu
+++ b/primitiv/device_ops/cuda/argmin.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/batch_sum.cu
+++ b/primitiv/device_ops/cuda/batch_sum.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/broadcast.cu
+++ b/primitiv/device_ops/cuda/broadcast.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/concat.cu
+++ b/primitiv/device_ops/cuda/concat.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/conv2d.cu
+++ b/primitiv/device_ops/cuda/conv2d.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/copy_tensor.cu
+++ b/primitiv/device_ops/cuda/copy_tensor.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/cos.cu
+++ b/primitiv/device_ops/cuda/cos.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/divide.cu
+++ b/primitiv/device_ops/cuda/divide.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/dump_description.cu
+++ b/primitiv/device_ops/cuda/dump_description.cu
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/elu.cu
+++ b/primitiv/device_ops/cuda/elu.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/exp.cu
+++ b/primitiv/device_ops/cuda/exp.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/identity.cu
+++ b/primitiv/device_ops/cuda/identity.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/inplace_add.cu
+++ b/primitiv/device_ops/cuda/inplace_add.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/inplace_multiply_const.cu
+++ b/primitiv/device_ops/cuda/inplace_multiply_const.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/inplace_subtract.cu
+++ b/primitiv/device_ops/cuda/inplace_subtract.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/log.cu
+++ b/primitiv/device_ops/cuda/log.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/logsumexp.cu
+++ b/primitiv/device_ops/cuda/logsumexp.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/matmul.cu
+++ b/primitiv/device_ops/cuda/matmul.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/max_pool2d.cu
+++ b/primitiv/device_ops/cuda/max_pool2d.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/multiply.cu
+++ b/primitiv/device_ops/cuda/multiply.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/negate.cu
+++ b/primitiv/device_ops/cuda/negate.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/new_handle.cu
+++ b/primitiv/device_ops/cuda/new_handle.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/pick.cu
+++ b/primitiv/device_ops/cuda/pick.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/pow.cu
+++ b/primitiv/device_ops/cuda/pow.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/pown.cu
+++ b/primitiv/device_ops/cuda/pown.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/prelu.cu
+++ b/primitiv/device_ops/cuda/prelu.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/random_bernoulli.cu
+++ b/primitiv/device_ops/cuda/random_bernoulli.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/random_log_normal.cu
+++ b/primitiv/device_ops/cuda/random_log_normal.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/random_normal.cu
+++ b/primitiv/device_ops/cuda/random_normal.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/random_uniform.cu
+++ b/primitiv/device_ops/cuda/random_uniform.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/reset_tensor.cu
+++ b/primitiv/device_ops/cuda/reset_tensor.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/reset_tensor_by_array.cu
+++ b/primitiv/device_ops/cuda/reset_tensor_by_array.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/sigmoid.cu
+++ b/primitiv/device_ops/cuda/sigmoid.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/sin.cu
+++ b/primitiv/device_ops/cuda/sin.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/slice.cu
+++ b/primitiv/device_ops/cuda/slice.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/softplus.cu
+++ b/primitiv/device_ops/cuda/softplus.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/sqrt.cu
+++ b/primitiv/device_ops/cuda/sqrt.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/subtract.cu
+++ b/primitiv/device_ops/cuda/subtract.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/sum.cu
+++ b/primitiv/device_ops/cuda/sum.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/tan.cu
+++ b/primitiv/device_ops/cuda/tan.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/tanh.cu
+++ b/primitiv/device_ops/cuda/tanh.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda/tensor_to_vector.cu
+++ b/primitiv/device_ops/cuda/tensor_to_vector.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda/transpose.cu
+++ b/primitiv/device_ops/cuda/transpose.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/add.cu
+++ b/primitiv/device_ops/cuda16/add.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/argmax.cu
+++ b/primitiv/device_ops/cuda16/argmax.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/argmin.cu
+++ b/primitiv/device_ops/cuda16/argmin.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/batch_sum.cu
+++ b/primitiv/device_ops/cuda16/batch_sum.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/broadcast.cu
+++ b/primitiv/device_ops/cuda16/broadcast.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/common.h
+++ b/primitiv/device_ops/cuda16/common.h
@@ -204,30 +204,4 @@ void CUDA16::name##_bw_impl( \
       MDATA(half, ga), MDATA(half, gb)); \
 }
 
-#define CUDA16DEV_FW_X(name) \
-void CUDA16::name##_fw_impl(const Tensor &x, Tensor &y) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-#define CUDA16DEV_BW_X(name) \
-void CUDA16::name##_bw_impl( \
-    const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-#define CUDA16DEV_FW_X_CONST(name) \
-void CUDA16::name##_fw_impl(const Tensor &x, float k, Tensor &y) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-#define CUDA16DEV_BW_X_CONST(name) \
-void CUDA16::name##_bw_impl( \
-    const Tensor &x, const Tensor &y, const Tensor &gy, float k, Tensor &gx) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-#define CUDA16DEV_FW_X_SCALAR(name) \
-void CUDA16::name##_fw_impl(const Tensor &x, const Tensor &k, Tensor &y) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-#define CUDA16DEV_FW_AB(name) \
-void CUDA16::name##_fw_impl(const Tensor &a, const Tensor &b, Tensor &y) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-#define CUDA16DEV_BW_AB(name) \
-void CUDA16::name##_bw_impl( \
-    const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy, \
-    Tensor &ga, Tensor &gb) { \
-  PRIMITIV_THROW_NOT_IMPLEMENTED; }
-
 #endif  // PRIMITIV_DEVICE_OPS_COMMON_CUDA16_H_

--- a/primitiv/device_ops/cuda16/common.h
+++ b/primitiv/device_ops/cuda16/common.h
@@ -206,28 +206,28 @@ void CUDA16::name##_bw_impl( \
 
 #define CUDA16DEV_FW_X(name) \
 void CUDA16::name##_fw_impl(const Tensor &x, Tensor &y) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 #define CUDA16DEV_BW_X(name) \
 void CUDA16::name##_bw_impl( \
     const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 #define CUDA16DEV_FW_X_CONST(name) \
 void CUDA16::name##_fw_impl(const Tensor &x, float k, Tensor &y) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 #define CUDA16DEV_BW_X_CONST(name) \
 void CUDA16::name##_bw_impl( \
     const Tensor &x, const Tensor &y, const Tensor &gy, float k, Tensor &gx) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 #define CUDA16DEV_FW_X_SCALAR(name) \
 void CUDA16::name##_fw_impl(const Tensor &x, const Tensor &k, Tensor &y) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 #define CUDA16DEV_FW_AB(name) \
 void CUDA16::name##_fw_impl(const Tensor &a, const Tensor &b, Tensor &y) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 #define CUDA16DEV_BW_AB(name) \
 void CUDA16::name##_bw_impl( \
     const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy, \
     Tensor &ga, Tensor &gb) { \
-  THROW_NOT_IMPLEMENTED; }
+  PRIMITIV_THROW_NOT_IMPLEMENTED; }
 
 #endif  // PRIMITIV_DEVICE_OPS_COMMON_CUDA16_H_

--- a/primitiv/device_ops/cuda16/concat.cu
+++ b/primitiv/device_ops/cuda16/concat.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/conv2d.cu
+++ b/primitiv/device_ops/cuda16/conv2d.cu
@@ -3,7 +3,7 @@
 #include <cstring>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda16/copy_tensor.cu
+++ b/primitiv/device_ops/cuda16/copy_tensor.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda16/cos.cu
+++ b/primitiv/device_ops/cuda16/cos.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/divide.cu
+++ b/primitiv/device_ops/cuda16/divide.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/dump_description.cu
+++ b/primitiv/device_ops/cuda16/dump_description.cu
@@ -3,7 +3,7 @@
 #include <iostream>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda16/elu.cu
+++ b/primitiv/device_ops/cuda16/elu.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/exp.cu
+++ b/primitiv/device_ops/cuda16/exp.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/identity.cu
+++ b/primitiv/device_ops/cuda16/identity.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/inplace_add.cu
+++ b/primitiv/device_ops/cuda16/inplace_add.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/inplace_multiply_const.cu
+++ b/primitiv/device_ops/cuda16/inplace_multiply_const.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/inplace_subtract.cu
+++ b/primitiv/device_ops/cuda16/inplace_subtract.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/log.cu
+++ b/primitiv/device_ops/cuda16/log.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/logsumexp.cu
+++ b/primitiv/device_ops/cuda16/logsumexp.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/matmul.cu
+++ b/primitiv/device_ops/cuda16/matmul.cu
@@ -3,7 +3,7 @@
 #include <cstring>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/max_pool2d.cu
+++ b/primitiv/device_ops/cuda16/max_pool2d.cu
@@ -3,7 +3,7 @@
 #include <cstring>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda16/multiply.cu
+++ b/primitiv/device_ops/cuda16/multiply.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/negate.cu
+++ b/primitiv/device_ops/cuda16/negate.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/new_handle.cu
+++ b/primitiv/device_ops/cuda16/new_handle.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace primitiv {

--- a/primitiv/device_ops/cuda16/pick.cu
+++ b/primitiv/device_ops/cuda16/pick.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/pow.cu
+++ b/primitiv/device_ops/cuda16/pow.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/pown.cu
+++ b/primitiv/device_ops/cuda16/pown.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/prelu.cu
+++ b/primitiv/device_ops/cuda16/prelu.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/random_bernoulli.cu
+++ b/primitiv/device_ops/cuda16/random_bernoulli.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/random_log_normal.cu
+++ b/primitiv/device_ops/cuda16/random_log_normal.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/random_normal.cu
+++ b/primitiv/device_ops/cuda16/random_normal.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/random_uniform.cu
+++ b/primitiv/device_ops/cuda16/random_uniform.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/reset_tensor.cu
+++ b/primitiv/device_ops/cuda16/reset_tensor.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/reset_tensor_by_array.cu
+++ b/primitiv/device_ops/cuda16/reset_tensor_by_array.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/sigmoid.cu
+++ b/primitiv/device_ops/cuda16/sigmoid.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/sin.cu
+++ b/primitiv/device_ops/cuda16/sin.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/slice.cu
+++ b/primitiv/device_ops/cuda16/slice.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/softplus.cu
+++ b/primitiv/device_ops/cuda16/softplus.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/sqrt.cu
+++ b/primitiv/device_ops/cuda16/sqrt.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/subtract.cu
+++ b/primitiv/device_ops/cuda16/subtract.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/sum.cu
+++ b/primitiv/device_ops/cuda16/sum.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/tan.cu
+++ b/primitiv/device_ops/cuda16/tan.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/tanh.cu
+++ b/primitiv/device_ops/cuda16/tanh.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/tensor_to_vector.cu
+++ b/primitiv/device_ops/cuda16/tensor_to_vector.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/cuda16/transpose.cu
+++ b/primitiv/device_ops/cuda16/transpose.cu
@@ -1,7 +1,7 @@
 #include <primitiv/config.h>
 
 #include <primitiv/cuda16_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/device_ops/cuda16/common.h>
 
 namespace {

--- a/primitiv/device_ops/eigen/new_handle.cc
+++ b/primitiv/device_ops/eigen/new_handle.cc
@@ -12,7 +12,7 @@ std::shared_ptr<void> Eigen::new_handle(const Shape &shape) {
   const std::uint32_t mem_size = sizeof(float) * shape.size();
   void *data = std::malloc(mem_size);
   if (!data) {
-    THROW_ERROR("Memory allocation failed. Requested size: " << mem_size);
+    PRIMITIV_THROW_ERROR("Memory allocation failed. Requested size: " << mem_size);
   }
   return std::shared_ptr<void>(data, std::free);
 }

--- a/primitiv/device_ops/naive/new_handle.cc
+++ b/primitiv/device_ops/naive/new_handle.cc
@@ -12,7 +12,7 @@ std::shared_ptr<void> Naive::new_handle(const Shape &shape) {
   const std::uint32_t mem_size = sizeof(float) * shape.size();
   void *data = std::malloc(mem_size);
   if (!data) {
-    THROW_ERROR("Memory allocation failed. Requested size: " << mem_size);
+    PRIMITIV_THROW_ERROR("Memory allocation failed. Requested size: " << mem_size);
   }
   return std::shared_ptr<void>(data, std::free);
 }

--- a/primitiv/error.h
+++ b/primitiv/error.h
@@ -43,17 +43,17 @@ public:
 
 }  // namespace primitiv
 
-#define THROW_ERROR(cmds) { \
+#define PRIMITIV_THROW_ERROR(cmds) { \
   std::stringstream ss; \
   ss << cmds; \
   throw primitiv::Error(__FILE__, __LINE__, ss.str()); \
 }
 
-#define THROW_NOT_IMPLEMENTED { \
+#define PRIMITIV_THROW_NOT_IMPLEMENTED { \
   throw primitiv::NotImplementedError(__FILE__, __LINE__, __func__); \
 }
 
-#define THROW_NOT_IMPLEMENTED_WITH_MESSAGE(cmds) { \
+#define PRIMITIV_THROW_NOT_IMPLEMENTED_WITH_MESSAGE(cmds) { \
   std::stringstream ss; \
   ss << cmds; \
   throw primitiv::NotImplementedError(__FILE__, __LINE__, ss.str()); \

--- a/primitiv/file_format.h
+++ b/primitiv/file_format.h
@@ -24,7 +24,7 @@ public:
 
   static void assert_version(std::uint32_t major, std::uint32_t minor) {
     if (major != CurrentVersion::MAJOR || minor != CurrentVersion::MINOR) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "File version mismatched. required: "
           << CurrentVersion::MAJOR << "." << CurrentVersion::MINOR
           << ", observed: "
@@ -34,7 +34,7 @@ public:
 
   static void assert_datatype(DataType required, std::uint32_t observed) {
     if (observed != static_cast<std::uint32_t>(required)) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "Data type mismatched. required: "
           << std::hex << static_cast<std::uint32_t>(required)
           << ", observed: "

--- a/primitiv/graph.cc
+++ b/primitiv/graph.cc
@@ -30,7 +30,7 @@ void Graph::clear() {
 
 #define CHECK_NODE(n) { \
   if ((n).g_ != this) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "Graph mismatched. node.g_: " << (n).g_ << " != this: " << this); \
   } \
   if ((n).op_id_ >= ops_.size() || \
@@ -70,7 +70,7 @@ Node Graph::add_operator(
     // If nullptr, the device object is inherited from `args[0]`.
     ret_device = args.size() > 0 ? &ACCESS(args[0]).device : nullptr;
     if (!ret_device) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "Bad device forwarding of operator '" << op->name()
           << "' with " << args.size() << " argument(s).");
     }
@@ -137,7 +137,7 @@ void Graph::backward(const Node &node) {
     last_v = &last_n.value;
     if (!last_v) {
       // NOTE(ocashi): Should never arrive here.
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "The node [op_id=" << node.op_id_ << ", val_id=" << node.val_id_
           << "] is not yet forwarded.");
     }
@@ -199,7 +199,7 @@ Device &Graph::get_device(const Node &node) const {
 }
 
 std::string Graph::dump(const std::string &format) const {
-  if (format != "dot") THROW_ERROR("Unknown format: " << format);
+  if (format != "dot") PRIMITIV_THROW_ERROR("Unknown format: " << format);
 
   std::stringstream ss;
   ss << R"(digraph ComputationGraph {

--- a/primitiv/graph.h
+++ b/primitiv/graph.h
@@ -52,7 +52,7 @@ public:
    * @return Graph object.
    */
   Graph &graph() const {
-    if (!valid()) THROW_ERROR("Invalid node.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
     return *g_;
   }
 
@@ -61,7 +61,7 @@ public:
    * @return Operator ID.
    */
   std::uint32_t operator_id() const {
-    if (!valid()) THROW_ERROR("Invalid node.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
     return op_id_;
   }
 
@@ -70,7 +70,7 @@ public:
    * @return Value ID.
    */
   std::uint32_t value_id() const {
-    if (!valid()) THROW_ERROR("Invalid node.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
     return val_id_;
   }
 
@@ -246,37 +246,37 @@ private:
 };
 
 inline Shape Node::shape() const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   return g_->get_shape(*this);
 }
 
 inline Device &Node::device() const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   return g_->get_device(*this);
 }
 
 inline float Node::to_float() const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   return g_->forward(*this).to_float();
 }
 
 inline std::vector<float> Node::to_vector() const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   return g_->forward(*this).to_vector();
 }
 
 inline std::vector<std::uint32_t> Node::argmax(std::uint32_t dim) const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   return g_->forward(*this).argmax(dim);
 }
 
 inline std::vector<std::uint32_t> Node::argmin(std::uint32_t dim) const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   return g_->forward(*this).argmin(dim);
 }
 
 inline void Node::backward() const {
-  if (!valid()) THROW_ERROR("Invalid node.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid node.");
   g_->backward(*this);
 }
 

--- a/primitiv/initializer_impl.cc
+++ b/primitiv/initializer_impl.cc
@@ -24,7 +24,7 @@ void Normal::apply(Tensor &x) const {
 void Identity::apply(Tensor &x) const {
   const Shape s = x.shape();
   if (!s.is_matrix() || s[0] != s[1]) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Identity initializer can be used to only square matrices.");
   }
   x = x.device().identity(s[0]);
@@ -33,7 +33,7 @@ void Identity::apply(Tensor &x) const {
 void XavierUniform::apply(Tensor &x) const {
   const Shape s = x.shape();
   if (!s.is_matrix()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "XavierUniform initializer can be used to only matrices or vectors.");
   }
   const float bound = scale_ * std::sqrt(6. / (s[0] + s[1]));
@@ -43,7 +43,7 @@ void XavierUniform::apply(Tensor &x) const {
 void XavierNormal::apply(Tensor &x) const {
   const Shape s = x.shape();
   if (!s.is_matrix()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "XavierNormal initializer can be used to only matrices or vectors.");
   }
   const float sd = scale_ * std::sqrt(2. / (s[0] + s[1]));
@@ -53,7 +53,7 @@ void XavierNormal::apply(Tensor &x) const {
 void XavierUniformConv2D::apply(Tensor &x) const {
   const Shape s = x.shape();
   if (s.depth() > 4) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "XavierUniformConv2D initializer can be used to only tensors with "
         "up to 4 dimensions.");
   }
@@ -66,7 +66,7 @@ void XavierUniformConv2D::apply(Tensor &x) const {
 void XavierNormalConv2D::apply(Tensor &x) const {
   const Shape s = x.shape();
   if (s.depth() > 4) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "XavierNormalConv2D initializer can be used to only tensors with "
         "up to 4 dimensions.");
   }

--- a/primitiv/internal/cuda_utils.cu
+++ b/primitiv/internal/cuda_utils.cu
@@ -1,6 +1,6 @@
 #include <primitiv/config.h>
 
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 
 namespace primitiv {
 namespace cuda {

--- a/primitiv/internal/cuda_utils.h
+++ b/primitiv/internal/cuda_utils.h
@@ -16,7 +16,7 @@
 #define CUDA_CALL(f) { \
   ::cudaError_t err = (f); \
   if (err != cudaSuccess) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "CUDA function failed.\n  statement: " << #f \
         << "\n  error: " << err \
         << ": " << ::cudaGetErrorString(err)); \
@@ -26,7 +26,7 @@
 #define CUBLAS_CALL(f) { \
   ::cublasStatus_t err = (f); \
   if (err != CUBLAS_STATUS_SUCCESS) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "CUBLAS function failed.\n  statement: " << #f \
         << "\n  error: " << err \
         << ": " << primitiv::cuda::cublasGetErrorString(err)); \
@@ -36,7 +36,7 @@
 #define CURAND_CALL(f) { \
   ::curandStatus_t err = (f); \
   if (err != CURAND_STATUS_SUCCESS) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "CURAND function failed.\n  statement: " << #f \
         << "\n  error: " << err \
         << ": " << primitiv::cuda::curandGetErrorString(err)); \
@@ -46,7 +46,7 @@
 #define CUDNN_CALL(f) { \
   ::cudnnStatus_t err = (f); \
   if (err != CUDNN_STATUS_SUCCESS) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "CUDNN function failed.\n  statement: " << #f \
         << "\n  error: " << err \
         << ": " << ::cudnnGetErrorString(err)); \
@@ -237,8 +237,9 @@ public:
           padding_h, padding_w, stride_h, stride_w, dilation_h, dilation_w,
           CUDNN_CONVOLUTION, data_type));
 #else
+    static_cast<void>(data_type);  // unused
     if (dilation_h > 1 || dilation_w > 1) {
-      THROW_NOT_IMPLEMENTED_WITH_MESSAGE(
+      PRIMITIV_THROW_NOT_IMPLEMENTED_WITH_MESSAGE(
           "Dilated convolution is supported by cuDNN 6.0 or later.");
     }
     CUDNN_CALL(::cudnnSetConvolution2dDescriptor(

--- a/primitiv/memory_pool.cc
+++ b/primitiv/memory_pool.cc
@@ -36,7 +36,7 @@ std::shared_ptr<void> MemoryPool::allocate(std::size_t size) {
 
   static const std::uint64_t MAX_SHIFTS = 63;
   const std::uint64_t shift = numeric_utils::calculate_shifts(size);
-  if (shift > MAX_SHIFTS) THROW_ERROR("Invalid memory size: " << size);
+  if (shift > MAX_SHIFTS) PRIMITIV_THROW_ERROR("Invalid memory size: " << size);
 
   void *ptr;
   if (reserved_[shift].empty()) {
@@ -65,7 +65,7 @@ std::shared_ptr<void> MemoryPool::allocate(std::size_t size) {
 void MemoryPool::free(void *ptr) {
   auto it = supplied_.find(ptr);
   if (it == supplied_.end()) {
-    THROW_ERROR("Detected to dispose unknown handle: " << ptr);
+    PRIMITIV_THROW_ERROR("Detected to dispose unknown handle: " << ptr);
   }
   reserved_[it->second].emplace_back(ptr);
   supplied_.erase(it);

--- a/primitiv/mixins.h
+++ b/primitiv/mixins.h
@@ -68,7 +68,7 @@ public:
   static T &get_object(std::uint64_t id) {
     const std::lock_guard<std::mutex> lock(mutex_);
     const auto it = objects_.find(id);
-    if (it == objects_.end()) THROW_ERROR("Invalid object ID: " << id);
+    if (it == objects_.end()) PRIMITIV_THROW_ERROR("Invalid object ID: " << id);
     return *it->second;
   }
 
@@ -118,7 +118,7 @@ public:
    * @throw primitiv::Error Default object is null.
    */
   static T &get_default() {
-    if (!default_obj_) THROW_ERROR("Default object is null.");
+    if (!default_obj_) PRIMITIV_THROW_ERROR("Default object is null.");
     return *default_obj_;
   }
 

--- a/primitiv/model.cc
+++ b/primitiv/model.cc
@@ -15,7 +15,7 @@ namespace primitiv {
 void Model::load(const std::string &path, bool with_stats, Device *device) {
   std::ifstream ifs(path);
   if (!ifs.is_open()) {
-    THROW_ERROR("Could not open file: " << path);
+    PRIMITIV_THROW_ERROR("Could not open file: " << path);
   }
   msgpack::Reader reader(ifs);
 
@@ -36,7 +36,7 @@ void Model::load(const std::string &path, bool with_stats, Device *device) {
     reader >> key;
     const auto it = params.find(key);
     if (it == params.end()) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "Model does not have a parameter with name: '"
           << string_utils::join(key, ".") << "'");
     }
@@ -48,7 +48,7 @@ void Model::load(const std::string &path, bool with_stats, Device *device) {
 void Model::save(const std::string &path, bool with_stats) const {
   std::ofstream ofs(path);
   if (!ofs.is_open()) {
-    THROW_ERROR("Could not open file: " << path);
+    PRIMITIV_THROW_ERROR("Could not open file: " << path);
   }
   msgpack::Writer writer(ofs);
 
@@ -58,7 +58,7 @@ void Model::save(const std::string &path, bool with_stats) const {
 
   const auto params = get_all_parameters();
   if (params.size() > 0xffffffffull) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Could not store more than 2^32 - 1 parameters in one model file.");
   }
   writer << static_cast<std::uint32_t>(params.size());
@@ -78,11 +78,11 @@ void Model::add(const std::string &name, Parameter &param) {
   }
 
   if (name_set_.find(name) != name_set_.end()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Name '" << name << "' already exists in the model.");
   }
   if (param_set_.find(&param) != param_set_.end()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Parameter '" << &param << "' already exists in the model.");
   }
 
@@ -100,17 +100,17 @@ void Model::add(const std::string &name, Model &model) {
   }
 
   if (&model == this) {
-    THROW_ERROR("Can't add self as a submodel.");
+    PRIMITIV_THROW_ERROR("Can't add self as a submodel.");
   }
   if (model.has_submodel(*this)) {
-    THROW_ERROR("Can't add an ancestor model as a submodel.");
+    PRIMITIV_THROW_ERROR("Can't add an ancestor model as a submodel.");
   }
   if (name_set_.find(name) != name_set_.end()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Name '" << name << "' already exists in the model.");
   }
   if (submodel_set_.find(&model) != submodel_set_.end()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Model '" << &model << "' already exists in the model.");
   }
 
@@ -125,7 +125,7 @@ const Model &Model::get_semiterminal(
   for (auto it = names.begin(), end = names.end() - 1; it != end; ++it) {
     const auto next = cur->submodel_kv_.find(*it);
     if (next == cur->submodel_kv_.end()) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "Parameter or submodel not found: "
           "'" << string_utils::join(names, ".") << "'");
     }
@@ -139,7 +139,7 @@ const Parameter &Model::get_parameter(
   const Model &st = get_semiterminal(names);
   const auto it = st.param_kv_.find(names.back());
   if (it == st.param_kv_.end()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Parameter not found: '" << string_utils::join(names, ".") << "'");
   }
   return *it->second;
@@ -149,7 +149,7 @@ const Model &Model::get_submodel(const std::vector<std::string> &names) const {
   const Model &st = get_semiterminal(names);
   const auto it = st.submodel_kv_.find(names.back());
   if (it == st.submodel_kv_.end()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Submodel not found: '" << string_utils::join(names, ".") << "'");
   }
   return *it->second;

--- a/primitiv/model.h
+++ b/primitiv/model.h
@@ -101,7 +101,7 @@ public:
   const Parameter &get_parameter(const std::string &name) const {
     const auto it = param_kv_.find(name);
     if (it == param_kv_.end()) {
-      THROW_ERROR("Parameter with name '" << name << "' not found.");
+      PRIMITIV_THROW_ERROR("Parameter with name '" << name << "' not found.");
     }
     return *it->second;
   }
@@ -166,7 +166,7 @@ public:
   const Model &get_submodel(const std::string &name) const {
     const auto it = submodel_kv_.find(name);
     if (it == submodel_kv_.end()) {
-      THROW_ERROR("Submodel with name '" << name << "' not found.");
+      PRIMITIV_THROW_ERROR("Submodel with name '" << name << "' not found.");
     }
     return *it->second;
   }

--- a/primitiv/msgpack/objects.h
+++ b/primitiv/msgpack/objects.h
@@ -79,7 +79,7 @@ public:
    * @throw primitiv::Error Object is invalid.
    */
   void check_valid() const {
-    if (!valid()) THROW_ERROR("MessagePack: Invalid 'Binary' object.");
+    if (!valid()) PRIMITIV_THROW_ERROR("MessagePack: Invalid 'Binary' object.");
   }
 
   /**
@@ -107,7 +107,9 @@ public:
    *          Users must not delete memory returned by this function.
    */
   char *allocate(std::size_t size) {
-    if (valid()) THROW_ERROR("MessagePack: 'Binary' object is already valid.");
+    if (valid()) {
+      PRIMITIV_THROW_ERROR("MessagePack: 'Binary' object is already valid.");
+    }
 
     // NOTE(odashi):
     // Allocation should be done at first (it may throws).
@@ -192,7 +194,9 @@ public:
    * @throw primitiv::Error Object is invalid.
    */
   void check_valid() const {
-    if (!valid()) THROW_ERROR("MessagePack: Invalid 'Extension' object.");
+    if (!valid()) {
+      PRIMITIV_THROW_ERROR("MessagePack: Invalid 'Extension' object.");
+    }
   }
 
   /**
@@ -230,7 +234,9 @@ public:
    *          Users must not delete memory returned by this function.
    */
   char *allocate(std::int8_t type, std::size_t size) {
-    if (valid()) THROW_ERROR("MessagePack: 'Extension' object is already valid.");
+    if (valid()) {
+      PRIMITIV_THROW_ERROR("MessagePack: 'Extension' object is already valid.");
+  }
 
     // NOTE(odashi):
     // Allocation should be done at first (it may throws).

--- a/primitiv/msgpack/reader.h
+++ b/primitiv/msgpack/reader.h
@@ -27,9 +27,10 @@ private:
   void check_eof() {
     if (!is_) {
       if (is_.eof()) {
-        THROW_ERROR("MessagePack: Stream reached EOF.");
+        PRIMITIV_THROW_ERROR("MessagePack: Stream reached EOF.");
       } else {
-        THROW_ERROR("MessagePack: An error occurred while reading the stream.");
+        PRIMITIV_THROW_ERROR(
+            "MessagePack: An error occurred while reading the stream.");
       }
     }
   }
@@ -54,16 +55,18 @@ private:
     return (c[0] << 24) | (c[1] << 16) | (c[2] << 8) | c[3];
   }
 
-#define ULL(expr) static_cast<std::uint64_t>(expr)
+#define PRIMITIV_ULL(expr) static_cast<std::uint64_t>(expr)
   std::uint64_t get_uint64() {
     std::uint8_t c[8];
     is_.read(reinterpret_cast<char *>(c), 8);
     check_eof();
-    return (ULL(c[0]) << 56) | (ULL(c[1]) << 48) | (ULL(c[2]) << 40) |
-      (ULL(c[3]) << 32) | (ULL(c[4]) << 24) | (ULL(c[5]) << 16) |
-      (ULL(c[6]) << 8) | ULL(c[7]);
+    return
+      (PRIMITIV_ULL(c[0]) << 56) | (PRIMITIV_ULL(c[1]) << 48) |
+      (PRIMITIV_ULL(c[2]) << 40) | (PRIMITIV_ULL(c[3]) << 32) |
+      (PRIMITIV_ULL(c[4]) << 24) | (PRIMITIV_ULL(c[5]) << 16) |
+      (PRIMITIV_ULL(c[6]) << 8) | PRIMITIV_ULL(c[7]);
   }
-#undef ULL
+#undef PRIMITIV_ULL
 
   void read(char *ptr, std::size_t size) {
     is_.read(ptr, size);
@@ -73,7 +76,7 @@ private:
   void check_type(std::uint8_t expected) {
     std::uint8_t observed = get_uint8();
     if (observed != expected) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "MessagePack: Next object does not have a correct type. "
           "expected: " << std::hex << static_cast<int>(expected)
           << ", observed: " << std::hex << static_cast<int>(observed));
@@ -98,7 +101,7 @@ public:
     if ((type & 0xfe) == 0xc2) {
       x = static_cast<bool>(type & 0x01);
     } else {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "MessagePack: Next object does not have the 'bool' type. "
           "observed: " << type);
     }
@@ -181,7 +184,7 @@ public:
         case 0xda: size = get_uint16(); break;
         case 0xdb: size = get_uint32(); break;
         default:
-          THROW_ERROR(
+          PRIMITIV_THROW_ERROR(
               "MessagePack: Next object does not have the 'str' type. "
               "observed: " << type);
       }
@@ -201,7 +204,7 @@ public:
       case 0xc5: size = get_uint16(); break;
       case 0xc6: size = get_uint32(); break;
       default:
-        THROW_ERROR(
+        PRIMITIV_THROW_ERROR(
             "MessagePack: Next object does not have the 'bin' type. "
             "observed: " << type);
     }
@@ -225,7 +228,7 @@ public:
       case 0xc8: size = get_uint16(); break;
       case 0xc9: size = get_uint32(); break;
       default:
-        THROW_ERROR(
+        PRIMITIV_THROW_ERROR(
             "MessagePack: Next object does not have the 'ext' type. "
             "observed: " << type);
     }
@@ -247,7 +250,7 @@ public:
         case 0xdc: size = get_uint16(); break;
         case 0xdd: size = get_uint32(); break;
         default:
-          THROW_ERROR(
+          PRIMITIV_THROW_ERROR(
               "MessagePack: Next object does not have the 'array' type. "
               "observed: " << type);
       }
@@ -270,7 +273,7 @@ public:
         case 0xde: size = get_uint16(); break;
         case 0xdf: size = get_uint32(); break;
         default:
-          THROW_ERROR(
+          PRIMITIV_THROW_ERROR(
               "MessagePack: Next object does not have the 'map' type. "
               "observed: " << type);
       }

--- a/primitiv/msgpack/writer.h
+++ b/primitiv/msgpack/writer.h
@@ -16,7 +16,7 @@
 namespace primitiv {
 namespace msgpack {
 
-#define UC(expr) static_cast<char>(expr)
+#define PRIMITIV_UC(expr) static_cast<char>(expr)
 
 /**
  * ostream-like MessagePack writer.
@@ -28,21 +28,25 @@ private:
   Writer &write_string(const char *x, std::size_t size) {
     static_assert(sizeof(std::size_t) > sizeof(std::uint32_t), "");
     if (size < (1 << 5)) {
-      const char buf[1] { UC(0xa0 | (size & 0x1f)) };
+      const char buf[1] { PRIMITIV_UC(0xa0 | (size & 0x1f)) };
       os_.write(buf, 1);
     } else if (size < (1ull << 8)) {
-      const char buf[2] { UC(0xd9), UC(size) };
+      const char buf[2] { PRIMITIV_UC(0xd9), PRIMITIV_UC(size) };
       os_.write(buf, 2);
     } else if (size < (1ull << 16)) {
-      const char buf[3] { UC(0xda), UC(size >> 8), UC(size) };
+      const char buf[3] {
+        PRIMITIV_UC(0xda), PRIMITIV_UC(size >> 8), PRIMITIV_UC(size)
+      };
       os_.write(buf, 3);
     } else if (size < (1ull << 32)) {
       const char buf[5] {
-        UC(0xdb), UC(size >> 24), UC(size >> 16), UC(size >> 8), UC(size),
+        PRIMITIV_UC(0xdb),
+        PRIMITIV_UC(size >> 24), PRIMITIV_UC(size >> 16),
+        PRIMITIV_UC(size >> 8), PRIMITIV_UC(size),
       };
       os_.write(buf, 5);
     } else {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "MessagePack: Can't store more than 2^32 - 1 bytes "
           "in one str message.");
     }
@@ -58,32 +62,36 @@ public:
   Writer(std::ostream &os) : os_(os) {}
 
   Writer &operator<<(std::nullptr_t) {
-    const char buf[1] { UC(0xc0) };
+    const char buf[1] { PRIMITIV_UC(0xc0) };
     os_.write(buf, 1);
     return *this;
   }
 
   Writer &operator<<(bool x) {
-    const char buf[2] { UC(0xc2), UC(0xc3) };
+    const char buf[2] { PRIMITIV_UC(0xc2), PRIMITIV_UC(0xc3) };
     os_.write(&buf[!!x], 1);
     return *this;
   }
 
   Writer &operator<<(std::uint8_t x) {
-    const char buf[2] { UC(0xcc), UC(x) };
+    const char buf[2] { PRIMITIV_UC(0xcc), PRIMITIV_UC(x) };
     os_.write(buf, 2);
     return *this;
   }
 
   Writer &operator<<(std::uint16_t x) {
-    const char buf[3] { UC(0xcd), UC(x >> 8), UC(x) };
+    const char buf[3] {
+      PRIMITIV_UC(0xcd), PRIMITIV_UC(x >> 8), PRIMITIV_UC(x)
+    };
     os_.write(buf, 3);
     return *this;
   }
 
   Writer &operator<<(std::uint32_t x) {
     const char buf[5] {
-      UC(0xce), UC(x >> 24), UC(x >> 16), UC(x >> 8), UC(x),
+      PRIMITIV_UC(0xce),
+      PRIMITIV_UC(x >> 24), PRIMITIV_UC(x >> 16),
+      PRIMITIV_UC(x >> 8), PRIMITIV_UC(x),
     };
     os_.write(buf, 5);
     return *this;
@@ -91,29 +99,35 @@ public:
 
   Writer &operator<<(std::uint64_t x) {
     const char buf[9] {
-      UC(0xcf),
-      UC(x >> 56), UC(x >> 48), UC(x >> 40), UC(x >> 32),
-      UC(x >> 24), UC(x >> 16), UC(x >> 8), UC(x),
+      PRIMITIV_UC(0xcf),
+      PRIMITIV_UC(x >> 56), PRIMITIV_UC(x >> 48),
+      PRIMITIV_UC(x >> 40), PRIMITIV_UC(x >> 32),
+      PRIMITIV_UC(x >> 24), PRIMITIV_UC(x >> 16),
+      PRIMITIV_UC(x >> 8), PRIMITIV_UC(x),
     };
     os_.write(buf, 9);
     return *this;
   }
 
   Writer &operator<<(std::int8_t x) {
-    const char buf[2] { UC(0xd0), UC(x) };
+    const char buf[2] { PRIMITIV_UC(0xd0), PRIMITIV_UC(x) };
     os_.write(buf, 2);
     return *this;
   }
 
   Writer &operator<<(std::int16_t x) {
-    const char buf[3] { UC(0xd1), UC(x >> 8), UC(x) };
+    const char buf[3] {
+      PRIMITIV_UC(0xd1), PRIMITIV_UC(x >> 8), PRIMITIV_UC(x)
+    };
     os_.write(buf, 3);
     return *this;
   }
 
   Writer &operator<<(std::int32_t x) {
     const char buf[5] {
-      UC(0xd2), UC(x >> 24), UC(x >> 16), UC(x >> 8), UC(x),
+      PRIMITIV_UC(0xd2),
+      PRIMITIV_UC(x >> 24), PRIMITIV_UC(x >> 16),
+      PRIMITIV_UC(x >> 8), PRIMITIV_UC(x),
     };
     os_.write(buf, 5);
     return *this;
@@ -121,9 +135,11 @@ public:
 
   Writer &operator<<(std::int64_t x) {
     const char buf[9] {
-      UC(0xd3),
-      UC(x >> 56), UC(x >> 48), UC(x >> 40), UC(x >> 32),
-      UC(x >> 24), UC(x >> 16), UC(x >> 8), UC(x),
+      PRIMITIV_UC(0xd3),
+      PRIMITIV_UC(x >> 56), PRIMITIV_UC(x >> 48),
+      PRIMITIV_UC(x >> 40), PRIMITIV_UC(x >> 32),
+      PRIMITIV_UC(x >> 24), PRIMITIV_UC(x >> 16),
+      PRIMITIV_UC(x >> 8), PRIMITIV_UC(x),
     };
     os_.write(buf, 9);
     return *this;
@@ -134,7 +150,9 @@ public:
     std::uint32_t y;
     std::memcpy(&y, &x, sizeof(float));
     const char buf[5] {
-      UC(0xca), UC(y >> 24), UC(y >> 16), UC(y >> 8), UC(y),
+      PRIMITIV_UC(0xca),
+      PRIMITIV_UC(y >> 24), PRIMITIV_UC(y >> 16),
+      PRIMITIV_UC(y >> 8), PRIMITIV_UC(y),
     };
     os_.write(buf, 5);
     return *this;
@@ -145,9 +163,11 @@ public:
     std::uint64_t y;
     std::memcpy(&y, &x, sizeof(double));
     const char buf[9] {
-      UC(0xcb),
-      UC(y >> 56), UC(y >> 48), UC(y >> 40), UC(y >> 32),
-      UC(y >> 24), UC(y >> 16), UC(y >> 8), UC(y),
+      PRIMITIV_UC(0xcb),
+      PRIMITIV_UC(y >> 56), PRIMITIV_UC(y >> 48),
+      PRIMITIV_UC(y >> 40), PRIMITIV_UC(y >> 32),
+      PRIMITIV_UC(y >> 24), PRIMITIV_UC(y >> 16),
+      PRIMITIV_UC(y >> 8), PRIMITIV_UC(y),
     };
     os_.write(buf, 9);
     return *this;
@@ -165,18 +185,22 @@ public:
     static_assert(sizeof(std::size_t) > sizeof(std::uint32_t), "");
     const std::size_t size = x.size();
     if (size < (1ull << 8)) {
-      const char buf[2] { UC(0xc4), UC(size) };
+      const char buf[2] { PRIMITIV_UC(0xc4), PRIMITIV_UC(size) };
       os_.write(buf, 2);
     } else if (size < (1ull << 16)) {
-      const char buf[3] { UC(0xc5), UC(size >> 8), UC(size) };
+      const char buf[3] {
+        PRIMITIV_UC(0xc5), PRIMITIV_UC(size >> 8), PRIMITIV_UC(size)
+      };
       os_.write(buf, 3);
     } else if (size < (1ull << 32)) {
       const char buf[5] {
-        UC(0xc6), UC(size >> 24), UC(size >> 16), UC(size >> 8), UC(size),
+        PRIMITIV_UC(0xc6),
+        PRIMITIV_UC(size >> 24), PRIMITIV_UC(size >> 16),
+        PRIMITIV_UC(size >> 8), PRIMITIV_UC(size),
       };
       os_.write(buf, 5);
     } else {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "MessagePack: Can't store more than 2^32 - 1 bytes "
           "in one bin message.");
     }
@@ -192,52 +216,58 @@ public:
       switch (size) {
         case 1:
           {
-            const char buf[2] { UC(0xd4), UC(type) };
+            const char buf[2] { PRIMITIV_UC(0xd4), PRIMITIV_UC(type) };
             os_.write(buf, 2);
             break;
           }
         case 2:
           {
-            const char buf[2] { UC(0xd5), UC(type) };
+            const char buf[2] { PRIMITIV_UC(0xd5), PRIMITIV_UC(type) };
             os_.write(buf, 2);
             break;
           }
         case 4:
           {
-            const char buf[2] { UC(0xd6), UC(type) };
+            const char buf[2] { PRIMITIV_UC(0xd6), PRIMITIV_UC(type) };
             os_.write(buf, 2);
             break;
           }
         case 8:
           {
-            const char buf[2] { UC(0xd7), UC(type) };
+            const char buf[2] { PRIMITIV_UC(0xd7), PRIMITIV_UC(type) };
             os_.write(buf, 2);
             break;
           }
         case 16:
           {
-            const char buf[2] { UC(0xd8), UC(type) };
+            const char buf[2] { PRIMITIV_UC(0xd8), PRIMITIV_UC(type) };
             os_.write(buf, 2);
             break;
           }
         default:
           {
-            const char buf[3] { UC(0xc7), UC(size), UC(type) };
+            const char buf[3] {
+              PRIMITIV_UC(0xc7), PRIMITIV_UC(size), PRIMITIV_UC(type)
+            };
             os_.write(buf, 3);
           }
       }
     } else if (size < (1ull << 16)) {
-      const char buf[4] { UC(0xc8), UC(size >> 8), UC(size), UC(type) };
+      const char buf[4] {
+        PRIMITIV_UC(0xc8), PRIMITIV_UC(size >> 8),
+        PRIMITIV_UC(size), PRIMITIV_UC(type)
+      };
       os_.write(buf, 4);
     } else if (size < (1ull << 32)) {
       const char buf[6] {
-        UC(0xc9),
-        UC(size >> 24), UC(size >> 16), UC(size >> 8), UC(size),
-        UC(type),
+        PRIMITIV_UC(0xc9),
+        PRIMITIV_UC(size >> 24), PRIMITIV_UC(size >> 16),
+        PRIMITIV_UC(size >> 8), PRIMITIV_UC(size),
+        PRIMITIV_UC(type),
       };
       os_.write(buf, 6);
     } else {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "MessagePack: Can't store more than 2^32 - 1 bytes "
           "in one ext message.");
     }
@@ -250,14 +280,18 @@ public:
     static_assert(sizeof(std::size_t) > sizeof(std::uint32_t), "");
     const std::size_t size = x.size();
     if (size < (1ull << 4)) {
-      const char buf[1] { UC(0x90 | (size & 0x0f)) };
+      const char buf[1] { PRIMITIV_UC(0x90 | (size & 0x0f)) };
       os_.write(buf, 1);
     } else if (size < (1ull << 16)) {
-      const char buf[3] { UC(0xdc), UC(size >> 8), UC(size) };
+      const char buf[3] {
+        PRIMITIV_UC(0xdc), PRIMITIV_UC(size >> 8), PRIMITIV_UC(size)
+      };
       os_.write(buf, 3);
     } else if (size < (1ull << 32)) {
       const char buf[5] {
-        UC(0xdd), UC(size >> 24), UC(size >> 16), UC(size >> 8), UC(size),
+        PRIMITIV_UC(0xdd),
+        PRIMITIV_UC(size >> 24), PRIMITIV_UC(size >> 16),
+        PRIMITIV_UC(size >> 8), PRIMITIV_UC(size),
       };
       os_.write(buf, 5);
     }
@@ -270,14 +304,18 @@ public:
     static_assert(sizeof(std::size_t) > sizeof(std::uint32_t), "");
     const std::size_t size = x.size();
     if (size < (1ull << 4)) {
-      const char buf[1] { UC(0x80 | (size & 0x0f)) };
+      const char buf[1] { PRIMITIV_UC(0x80 | (size & 0x0f)) };
       os_.write(buf, 1);
     } else if (size < (1ull << 16)) {
-      const char buf[3] { UC(0xde), UC(size >> 8), UC(size) };
+      const char buf[3] {
+        PRIMITIV_UC(0xde), PRIMITIV_UC(size >> 8), PRIMITIV_UC(size)
+      };
       os_.write(buf, 3);
     } else if (size < (1ull << 32)) {
       const char buf[5] {
-        UC(0xdf), UC(size >> 24), UC(size >> 16), UC(size >> 8), UC(size),
+        PRIMITIV_UC(0xdf),
+        PRIMITIV_UC(size >> 24), PRIMITIV_UC(size >> 16),
+        PRIMITIV_UC(size >> 8), PRIMITIV_UC(size),
       };
       os_.write(buf, 5);
     }
@@ -286,7 +324,7 @@ public:
   }
 };
 
-#undef UC
+#undef PRIMITIV_UC
 
 }  // namespace msgpack
 }  // namespace primitiv

--- a/primitiv/node_funcs.cc
+++ b/primitiv/node_funcs.cc
@@ -140,7 +140,7 @@ Node slice(
 
 template<>
 Node concat(const std::vector<Node> &xs, std::uint32_t dim) {
-  if (xs.empty()) THROW_ERROR("No nodes to concat.");
+  if (xs.empty()) PRIMITIV_THROW_ERROR("No nodes to concat.");
   return xs[0].graph().add_operator(
       std::unique_ptr<Operator>(new operators::Concat(dim)), xs);
 }

--- a/primitiv/opencl_device.cc
+++ b/primitiv/opencl_device.cc
@@ -105,7 +105,7 @@ std::vector<cl::Platform> get_all_platforms() {
 std::vector<cl::Device> get_all_devices(std::uint32_t platform_id) {
   const auto all_pfs = ::get_all_platforms();
   if (platform_id >= all_pfs.size()) {
-    THROW_ERROR("Invalid platform ID: " << platform_id);
+    PRIMITIV_THROW_ERROR("Invalid platform ID: " << platform_id);
   }
   std::vector<cl::Device> ret;
   all_pfs[platform_id].getDevices(CL_DEVICE_TYPE_ALL, &ret);
@@ -121,7 +121,7 @@ std::vector<cl::Device> get_all_devices(std::uint32_t platform_id) {
 cl::Device get_device(std::uint32_t platform_id, std::uint32_t device_id) {
   const auto all_devs = ::get_all_devices(platform_id);
   if (device_id >= all_devs.size()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid device ID: " << device_id
         << " (on the platform " << platform_id << ")");
   }
@@ -204,7 +204,7 @@ public:
       try {
         program.build({device});
       } catch (...) {
-        THROW_ERROR("OpenCL kernel compile error:" << std::endl << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device));
+        PRIMITIV_THROW_ERROR("OpenCL kernel compile error:" << std::endl << program.getBuildInfo<CL_PROGRAM_BUILD_LOG>(device));
       }
 
 #define CONFIGURE_KERNEL(name) \
@@ -460,7 +460,7 @@ void OpenCL::assert_support(
 
   // Checks whether the device is globally available.
   if (!dev.getInfo<CL_DEVICE_AVAILABLE>()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "OpenCL Device " << device_id << " on the platform " << platform_id
         << " is not available (CL_DEVICE_AVAILABLE == false).");
   }
@@ -470,7 +470,7 @@ void OpenCL::assert_support(
   { \
     const auto actual = dev.getInfo<name>(); \
     if (actual < (value)) { \
-      THROW_ERROR( \
+      PRIMITIV_THROW_ERROR( \
           "OpenCL Device " << device_id << " on the platform " << platform_id \
           << " does not satisfy the minimum requirement by primitiv. " \
           << "property: " << #name << ", " \
@@ -482,7 +482,7 @@ void OpenCL::assert_support(
   { \
     const auto actual = dev.getInfo<name>()[index]; \
     if (actual < (value)) { \
-      THROW_ERROR( \
+      PRIMITIV_THROW_ERROR( \
           "OpenCL Device " << device_id << " on the platform " << platform_id \
           << " does not satisfy the minimum requirement by primitiv. " \
           << "property: " << #name << "[" << #index << "], " \
@@ -1334,7 +1334,7 @@ void OpenCL::conv2d_fw_impl(const Tensor &, const Tensor &,
     std::uint32_t, std::uint32_t,
     std::uint32_t, std::uint32_t,
     Tensor &) {
-  THROW_NOT_IMPLEMENTED;
+  PRIMITIV_THROW_NOT_IMPLEMENTED;
 }
 
 void OpenCL::conv2d_bw_impl(
@@ -1343,7 +1343,7 @@ void OpenCL::conv2d_bw_impl(
     std::uint32_t, std::uint32_t,
     std::uint32_t, std::uint32_t,
     Tensor &, Tensor &) {
-  THROW_NOT_IMPLEMENTED;
+  PRIMITIV_THROW_NOT_IMPLEMENTED;
 }
 
 void OpenCL::max_pool2d_fw_impl(
@@ -1352,7 +1352,7 @@ void OpenCL::max_pool2d_fw_impl(
     std::uint32_t, std::uint32_t,
     std::uint32_t, std::uint32_t,
     Tensor &) {
-  THROW_NOT_IMPLEMENTED;
+  PRIMITIV_THROW_NOT_IMPLEMENTED;
 }
 
 void OpenCL::max_pool2d_bw_impl(
@@ -1361,7 +1361,7 @@ void OpenCL::max_pool2d_bw_impl(
     std::uint32_t, std::uint32_t,
     std::uint32_t, std::uint32_t,
     Tensor &) {
-  THROW_NOT_IMPLEMENTED;
+  PRIMITIV_THROW_NOT_IMPLEMENTED;
 }
 
 void OpenCL::inplace_multiply_const_impl(float k, Tensor &x) {

--- a/primitiv/operator_impl.cc
+++ b/primitiv/operator_impl.cc
@@ -15,7 +15,7 @@ namespace operators {
 
 #define CHECK_ARGNUM(args, n) \
   if (args.size() != n) { \
-    THROW_ERROR( \
+    PRIMITIV_THROW_ERROR( \
         "Number of arguments mismatched." \
         << " operator: " << name() \
         << ", required: " << n \
@@ -27,7 +27,7 @@ Input::Input(const Shape &shape, const vector<float> &data, Device &device)
 , data_(data)
 , device_(device) {
   if (data_.size() != shape_.size()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Data sizes mismatched."
         << " operator: Input"
         << ", required: " << shape_.size() << " (" << shape_.to_string() << ")"
@@ -57,7 +57,7 @@ Shape ParameterInput::forward_shape(const vector<const Shape *> &args) const {
 }
 
 Tensor ParameterInput::forward(const vector<const Tensor *> &) {
-  THROW_ERROR(
+  PRIMITIV_THROW_ERROR(
       "Attempted to get return values of ParameterInput via forward().");
 }
 

--- a/primitiv/operator_impl.h
+++ b/primitiv/operator_impl.h
@@ -13,7 +13,7 @@ class Device;
 
 namespace operators {
 
-#define DEFAULT_CLASS_DECL(name_) \
+#define PRIMITIV_DEFAULT_CLASS_DECL(name_) \
 public: \
   Shape forward_shape(const std::vector<const Shape *> &args) const override; \
   Tensor forward(const std::vector<const Tensor *> &args) override; \
@@ -23,13 +23,13 @@ public: \
       const std::vector<const Tensor *> &arg_values, \
       const std::vector<Tensor *> &arg_grads) const override;
 
-#define NO_CTOR_CLASS_DECL(name_) \
-  DEFAULT_CLASS_DECL(name_); \
+#define PRIMITIV_NO_CTOR_CLASS_DECL(name_) \
+  PRIMITIV_DEFAULT_CLASS_DECL(name_); \
 private: \
   name_() = delete;
 
 class Input : public Operator {
-  NO_CTOR_CLASS_DECL(Input);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Input);
 public:
   Input(const Shape &shape, const std::vector<float> &data, Device &device);
   Device *get_device() const override { return &device_; }
@@ -41,7 +41,7 @@ private:
 };
 
 class ParameterInput : public Operator {
-  NO_CTOR_CLASS_DECL(ParameterInput);
+  PRIMITIV_NO_CTOR_CLASS_DECL(ParameterInput);
 public:
   explicit ParameterInput(Parameter &param) : param_(param) {}
   Device *get_device() const override { return &param_.device(); }
@@ -52,7 +52,7 @@ private:
 };
 
 class Copy : public Operator {
-  NO_CTOR_CLASS_DECL(Copy);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Copy);
 public:
   Copy(Device &device) : device_(device) {}
   Device *get_device() const override { return &device_; }
@@ -62,7 +62,7 @@ private:
 };
 
 class Constant : public Operator {
-  NO_CTOR_CLASS_DECL(Constant);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Constant);
 public:
   Constant(const Shape &shape, float k, Device &device)
     : shape_(shape), k_(k), device_(device) {}
@@ -77,7 +77,7 @@ private:
 };
 
 class IdentityMatrix : public Operator {
-  NO_CTOR_CLASS_DECL(IdentityMatrix);
+  PRIMITIV_NO_CTOR_CLASS_DECL(IdentityMatrix);
 public:
   IdentityMatrix(std::uint32_t size, Device &device)
     : size_(size), device_(device) {}
@@ -91,7 +91,7 @@ private:
 };
 
 class RandomBernoulli : public Operator {
-  NO_CTOR_CLASS_DECL(RandomBernoulli);
+  PRIMITIV_NO_CTOR_CLASS_DECL(RandomBernoulli);
 public:
   RandomBernoulli(const Shape &shape, float p, Device &device)
     : shape_(shape), p_(p), device_(device) {}
@@ -106,7 +106,7 @@ private:
 };
 
 class RandomUniform : public Operator {
-  NO_CTOR_CLASS_DECL(RandomUniform);
+  PRIMITIV_NO_CTOR_CLASS_DECL(RandomUniform);
 public:
   RandomUniform(const Shape &shape, float lower, float upper, Device &device)
     : shape_(shape), lower_(lower), upper_(upper), device_(device) {}
@@ -124,7 +124,7 @@ private:
 };
 
 class RandomNormal : public Operator {
-  NO_CTOR_CLASS_DECL(RandomNormal);
+  PRIMITIV_NO_CTOR_CLASS_DECL(RandomNormal);
 public:
   RandomNormal(const Shape &shape, float mean, float sd, Device &device)
     : shape_(shape), mean_(mean), sd_(sd), device_(device) {}
@@ -142,7 +142,7 @@ private:
 };
 
 class RandomLogNormal : public Operator {
-  NO_CTOR_CLASS_DECL(RandomLogNormal);
+  PRIMITIV_NO_CTOR_CLASS_DECL(RandomLogNormal);
 public:
   RandomLogNormal(const Shape &shape, float mean, float sd, Device &device)
     : shape_(shape), mean_(mean), sd_(sd), device_(device) {}
@@ -160,7 +160,7 @@ private:
 };
 
 class Pick : public Operator {
-  NO_CTOR_CLASS_DECL(Pick);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Pick);
 public:
   Pick(const std::vector<std::uint32_t> &ids, std::uint32_t dim)
     : ids_(ids), dim_(dim) {}
@@ -173,7 +173,7 @@ private:
 };
 
 class Slice : public Operator {
-  NO_CTOR_CLASS_DECL(Slice);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Slice);
 public:
   Slice(std::uint32_t dim, std::uint32_t lower, std::uint32_t upper)
     : dim_(dim), lower_(lower), upper_(upper) {}
@@ -188,7 +188,7 @@ private:
 };
 
 class Concat : public Operator {
-  NO_CTOR_CLASS_DECL(Concat);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Concat);
 public:
   Concat(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
@@ -199,7 +199,7 @@ private:
 };
 
 class Reshape : public Operator {
-  NO_CTOR_CLASS_DECL(Reshape);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Reshape);
 public:
   explicit Reshape(const Shape &shape) : shape_(shape) {}
   std::string name() const override {
@@ -210,7 +210,7 @@ private:
 };
 
 class Sum : public Operator {
-  NO_CTOR_CLASS_DECL(Sum);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Sum);
 public:
   explicit Sum(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
@@ -221,7 +221,7 @@ private:
 };
 
 class LogSumExp : public Operator {
-  NO_CTOR_CLASS_DECL(LogSumExp);
+  PRIMITIV_NO_CTOR_CLASS_DECL(LogSumExp);
 public:
   explicit LogSumExp(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
@@ -232,7 +232,7 @@ private:
 };
 
 class Broadcast : public Operator {
-  NO_CTOR_CLASS_DECL(Broadcast);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Broadcast);
 public:
   Broadcast(std::uint32_t dim, std::uint32_t size) : dim_(dim), size_(size) {}
   std::string name() const override {
@@ -245,7 +245,7 @@ private:
 };
 
 class SoftmaxCrossEntropy : public Operator {
-  NO_CTOR_CLASS_DECL(SoftmaxCrossEntropy);
+  PRIMITIV_NO_CTOR_CLASS_DECL(SoftmaxCrossEntropy);
 public:
   explicit SoftmaxCrossEntropy(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
@@ -256,7 +256,7 @@ private:
 };
 
 class SparseSoftmaxCrossEntropy : public Operator {
-  NO_CTOR_CLASS_DECL(SparseSoftmaxCrossEntropy);
+  PRIMITIV_NO_CTOR_CLASS_DECL(SparseSoftmaxCrossEntropy);
 public:
   explicit SparseSoftmaxCrossEntropy(
       const std::vector<std::uint32_t> ids, std::uint32_t dim) : ids_(ids), dim_(dim) {}
@@ -270,25 +270,25 @@ private:
 };
 
 class StopGradient : public Operator {
-  DEFAULT_CLASS_DECL(StopGradient);
+  PRIMITIV_DEFAULT_CLASS_DECL(StopGradient);
 public:
   StopGradient() {}
   std::string name() const override { return "StopGradient"; }
 };
 
 // Operator with no parameter.
-#define DECL_OPERATOR(name_) \
+#define PRIMITIV_DECL_OPERATOR(name_) \
   class name_ : public Operator { \
-    DEFAULT_CLASS_DECL(name_); \
+    PRIMITIV_DEFAULT_CLASS_DECL(name_); \
   public: \
     name_() {} \
     std::string name() const override { return #name_; } \
   }
 
 // Operator with a constant.
-#define DECL_OPERATOR_K(name_) \
+#define PRIMITIV_DECL_OPERATOR_K(name_) \
   class name_ : public Operator { \
-    NO_CTOR_CLASS_DECL(name_); \
+    PRIMITIV_NO_CTOR_CLASS_DECL(name_); \
   public: \
     explicit name_(float k) : k_(k) {} \
     std::string name() const override { \
@@ -298,24 +298,24 @@ public:
     float k_; \
   }
 
-DECL_OPERATOR(Flatten);
+PRIMITIV_DECL_OPERATOR(Flatten);
 
-DECL_OPERATOR(Positive);
-DECL_OPERATOR(Negative);
+PRIMITIV_DECL_OPERATOR(Positive);
+PRIMITIV_DECL_OPERATOR(Negative);
 
-DECL_OPERATOR_K(AddConst);
-DECL_OPERATOR_K(SubtractConstR);
-DECL_OPERATOR_K(SubtractConstL);
-DECL_OPERATOR_K(MultiplyConst);
-DECL_OPERATOR_K(DivideConstR);
-DECL_OPERATOR_K(DivideConstL);
-DECL_OPERATOR_K(PowConstR);
-DECL_OPERATOR_K(PowConstL);
-DECL_OPERATOR_K(PReLU);
-DECL_OPERATOR_K(ELU);
+PRIMITIV_DECL_OPERATOR_K(AddConst);
+PRIMITIV_DECL_OPERATOR_K(SubtractConstR);
+PRIMITIV_DECL_OPERATOR_K(SubtractConstL);
+PRIMITIV_DECL_OPERATOR_K(MultiplyConst);
+PRIMITIV_DECL_OPERATOR_K(DivideConstR);
+PRIMITIV_DECL_OPERATOR_K(DivideConstL);
+PRIMITIV_DECL_OPERATOR_K(PowConstR);
+PRIMITIV_DECL_OPERATOR_K(PowConstL);
+PRIMITIV_DECL_OPERATOR_K(PReLU);
+PRIMITIV_DECL_OPERATOR_K(ELU);
 
 class PowN : public Operator {
-  NO_CTOR_CLASS_DECL(PowN);
+  PRIMITIV_NO_CTOR_CLASS_DECL(PowN);
 public:
   explicit PowN(std::int32_t k) : k_(k) {}
   std::string name() const override {
@@ -325,40 +325,40 @@ private:
   std::int32_t k_;
 };
 
-DECL_OPERATOR(AddScalar);
-DECL_OPERATOR(SubtractScalarR);
-DECL_OPERATOR(SubtractScalarL);
-DECL_OPERATOR(MultiplyScalar);
-DECL_OPERATOR(DivideScalarR);
-DECL_OPERATOR(DivideScalarL);
-DECL_OPERATOR(PowScalarR);
-DECL_OPERATOR(PowScalarL);
+PRIMITIV_DECL_OPERATOR(AddScalar);
+PRIMITIV_DECL_OPERATOR(SubtractScalarR);
+PRIMITIV_DECL_OPERATOR(SubtractScalarL);
+PRIMITIV_DECL_OPERATOR(MultiplyScalar);
+PRIMITIV_DECL_OPERATOR(DivideScalarR);
+PRIMITIV_DECL_OPERATOR(DivideScalarL);
+PRIMITIV_DECL_OPERATOR(PowScalarR);
+PRIMITIV_DECL_OPERATOR(PowScalarL);
 
-DECL_OPERATOR(Add);
-DECL_OPERATOR(Subtract);
-DECL_OPERATOR(Multiply);
-DECL_OPERATOR(Divide);
-DECL_OPERATOR(Pow);
+PRIMITIV_DECL_OPERATOR(Add);
+PRIMITIV_DECL_OPERATOR(Subtract);
+PRIMITIV_DECL_OPERATOR(Multiply);
+PRIMITIV_DECL_OPERATOR(Divide);
+PRIMITIV_DECL_OPERATOR(Pow);
 
-DECL_OPERATOR(Transpose);
-DECL_OPERATOR(MatrixMultiply);
+PRIMITIV_DECL_OPERATOR(Transpose);
+PRIMITIV_DECL_OPERATOR(MatrixMultiply);
 
-DECL_OPERATOR(Sqrt);
-DECL_OPERATOR(Exp);
-DECL_OPERATOR(Log);
-DECL_OPERATOR(Tanh);
-DECL_OPERATOR(Sigmoid);
-DECL_OPERATOR(Softplus);
-DECL_OPERATOR(Sin);
-DECL_OPERATOR(Cos);
-DECL_OPERATOR(Tan);
-DECL_OPERATOR(ReLU);
-DECL_OPERATOR(LReLU);
+PRIMITIV_DECL_OPERATOR(Sqrt);
+PRIMITIV_DECL_OPERATOR(Exp);
+PRIMITIV_DECL_OPERATOR(Log);
+PRIMITIV_DECL_OPERATOR(Tanh);
+PRIMITIV_DECL_OPERATOR(Sigmoid);
+PRIMITIV_DECL_OPERATOR(Softplus);
+PRIMITIV_DECL_OPERATOR(Sin);
+PRIMITIV_DECL_OPERATOR(Cos);
+PRIMITIV_DECL_OPERATOR(Tan);
+PRIMITIV_DECL_OPERATOR(ReLU);
+PRIMITIV_DECL_OPERATOR(LReLU);
 
-DECL_OPERATOR(BatchSum);
+PRIMITIV_DECL_OPERATOR(BatchSum);
 
 class Convolution2D : public Operator {
-  NO_CTOR_CLASS_DECL(Convolution2D);
+  PRIMITIV_NO_CTOR_CLASS_DECL(Convolution2D);
 
 public:
   Convolution2D(
@@ -386,7 +386,7 @@ private:
 };
 
 class MaxPooling2D : public Operator {
-  NO_CTOR_CLASS_DECL(MaxPooling2D);
+  PRIMITIV_NO_CTOR_CLASS_DECL(MaxPooling2D);
 
 public:
   MaxPooling2D(
@@ -413,10 +413,10 @@ private:
   std::uint32_t stride0_, stride1_;
 };
 
-#undef DECL_OPERATOR
-#undef DECL_OPERATOR_K
-#undef NO_CTOR_CLASS_DECL
-#undef DEFAULT_CLASS_DECL
+#undef PRIMITIV_DECL_OPERATOR
+#undef PRIMITIV_DECL_OPERATOR_K
+#undef PRIMITIV_NO_CTOR_CLASS_DECL
+#undef PRIMITIV_DEFAULT_CLASS_DECL
 
 }  // namespace operators
 }  // namespace primitiv

--- a/primitiv/optimizer.cc
+++ b/primitiv/optimizer.cc
@@ -16,7 +16,7 @@ namespace primitiv {
 void Optimizer::load(const std::string &path) {
   std::ifstream ifs(path);
   if (!ifs.is_open()) {
-    THROW_ERROR("Could not open file: " << path);
+    PRIMITIV_THROW_ERROR("Could not open file: " << path);
   }
   msgpack::Reader reader(ifs);
 
@@ -41,7 +41,7 @@ void Optimizer::save(const std::string &path) const {
 
   std::ofstream ofs(path);
   if (!ofs.is_open()) {
-    THROW_ERROR("Could not open file: " << path);
+    PRIMITIV_THROW_ERROR("Could not open file: " << path);
   }
   msgpack::Writer writer(ofs);
 

--- a/primitiv/optimizer.h
+++ b/primitiv/optimizer.h
@@ -57,7 +57,7 @@ public:
    * @remarks Could not set negative values.
    */
   void set_learning_rate_scaling(float scale) {
-    if (scale < 0) THROW_ERROR(
+    if (scale < 0) PRIMITIV_THROW_ERROR(
         "Could not set negative value to learning_rate_scaling.");
     lr_scale_ = scale;
   }
@@ -74,7 +74,7 @@ public:
    * @remarks Could not set negative values.
    */
   void set_weight_decay(float strength) {
-    if (strength < 0) THROW_ERROR(
+    if (strength < 0) PRIMITIV_THROW_ERROR(
         "Could not set negative value to weight_decay.");
     l2_strength_ = strength;
   }
@@ -91,7 +91,7 @@ public:
    * @remarks Could not set negative values.
    */
   void set_gradient_clipping(float threshold) {
-    if (threshold < 0) THROW_ERROR(
+    if (threshold < 0) PRIMITIV_THROW_ERROR(
         "Could not set negative value to gradient_clipping.");
     clip_threshold_ = threshold;
   }

--- a/primitiv/optimizer_impl.h
+++ b/primitiv/optimizer_impl.h
@@ -6,7 +6,7 @@
 namespace primitiv {
 namespace optimizers {
 
-#define DECL_DEFAULTS \
+#define PRIMITIV_DECL_DEFAULTS \
 public: \
   void get_configs( \
       std::unordered_map<std::string, std::uint32_t> &uint_configs, \
@@ -22,7 +22,7 @@ private: \
  * Simple stochastic gradient descent.
  */
 class SGD : public primitiv::Optimizer {
-  DECL_DEFAULTS;
+  PRIMITIV_DECL_DEFAULTS;
 
 public:
   /**
@@ -45,7 +45,7 @@ private:
  * Stochastic gradient descent with momentum.
  */
 class MomentumSGD : public primitiv::Optimizer {
-  DECL_DEFAULTS;
+  PRIMITIV_DECL_DEFAULTS;
 
 public:
   /**
@@ -77,7 +77,7 @@ private:
  * AdaGrad optimizer.
  */
 class AdaGrad : public primitiv::Optimizer {
-  DECL_DEFAULTS;
+  PRIMITIV_DECL_DEFAULTS;
 
 public:
   /**
@@ -109,7 +109,7 @@ private:
  * RMSProp Optimizer.
  */
 class RMSProp : public primitiv::Optimizer {
-  DECL_DEFAULTS;
+  PRIMITIV_DECL_DEFAULTS;
 
 public:
   /**
@@ -150,7 +150,7 @@ private:
  * https://arxiv.org/abs/1212.5701
  */
 class AdaDelta : public primitiv::Optimizer {
-  DECL_DEFAULTS;
+  PRIMITIV_DECL_DEFAULTS;
 
 public:
   /**
@@ -183,7 +183,7 @@ private:
  * https://arxiv.org/abs/1412.6980
  */
 class Adam : public primitiv::Optimizer {
-  DECL_DEFAULTS;
+  PRIMITIV_DECL_DEFAULTS;
 
 public:
   /**
@@ -229,7 +229,7 @@ private:
   float eps_;
 };
 
-#undef DECL_DEFAULTS
+#undef PRIMITIV_DECL_DEFAULTS
 
 }  // namespace optimizers
 }  // namespace primitiv

--- a/primitiv/parameter.cc
+++ b/primitiv/parameter.cc
@@ -28,7 +28,7 @@ primitiv::Tensor read_tensor(
   primitiv::msgpack::objects::Binary data;
   reader >> data;
   if (data.size() != shape.size() * sizeof(float)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape and data length mismatched. "
         "shape.size() * sizeof(float): " << (shape.size() * sizeof(float))
         << " != data.size(): " << data.size());
@@ -61,12 +61,12 @@ void assert_shape(
   const primitiv::Shape &sv = value.shape();
   const primitiv::Shape &sg = grad.shape();
   if (sv != sg) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched between value and gradient. value: "
         << sv.to_string() << ", gradient: " << sg.to_string());
   }
   if (sv.has_batch()) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "The batch size of the parameter should be 1. shape: "
         << sv.to_string());
   }
@@ -162,7 +162,7 @@ void Parameter::save_inner(msgpack::Writer &writer, bool with_stats) const {
 
   if (with_stats) {
     if (stats_.size() > 0xffffffffull) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "Could not store more than 2^32 - 1 stats in one parameter file.");
     }
     writer << static_cast<std::uint32_t>(stats_.size());
@@ -178,7 +178,7 @@ void Parameter::save_inner(msgpack::Writer &writer, bool with_stats) const {
 void Parameter::load(const string &path, bool with_stats, Device *device) {
   std::ifstream ifs(path);
   if (!ifs.is_open()) {
-    THROW_ERROR("Could not open file: " << path);
+    PRIMITIV_THROW_ERROR("Could not open file: " << path);
   }
   msgpack::Reader reader(ifs);
 
@@ -194,11 +194,11 @@ void Parameter::load(const string &path, bool with_stats, Device *device) {
 }
 
 void Parameter::save(const string &path, bool with_stats) const  {
-  if (!valid()) THROW_ERROR("Attempted to save an invalid Parameter object.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Attempted to save an invalid Parameter object.");
 
   std::ofstream ofs(path);
   if (!ofs.is_open()) {
-    THROW_ERROR("Could not open file: " << path);
+    PRIMITIV_THROW_ERROR("Could not open file: " << path);
   }
   msgpack::Writer writer(ofs);
 
@@ -210,14 +210,14 @@ void Parameter::save(const string &path, bool with_stats) const  {
 }
 
 void Parameter::reset_gradient() {
-  if (!valid()) THROW_ERROR("Invalid parameter.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
   grad_.reset(0);
 }
 
 void Parameter::add_stats(const string &name, const Shape &shape) {
-  if (!valid()) THROW_ERROR("Invalid parameter.");
+  if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
   if (has_stats(name)) {
-    THROW_ERROR("Statistics with name `" << name << "` already exists.");
+    PRIMITIV_THROW_ERROR("Statistics with name `" << name << "` already exists.");
   }
   stats_.emplace(
       std::make_pair(name, functions::zeros<Tensor>(shape, device_)));

--- a/primitiv/parameter.h
+++ b/primitiv/parameter.h
@@ -242,7 +242,7 @@ public:
    * @return true if the entry exists, false otherwise.
    */
   bool has_stats(const std::string &name) const {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return stats_.find(name) != stats_.end();
   }
 
@@ -251,7 +251,7 @@ public:
    * @return Shape object.
    */
   Shape shape() const {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return shape_;
   }
 
@@ -260,7 +260,7 @@ public:
    * @return Pointer of the Device object.
    */
   Device &device() const {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return *device_;
   }
 
@@ -269,7 +269,7 @@ public:
    * @return A tensor representing the parameter tensor.
    */
   const Tensor &value() const {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return value_;
   }
 
@@ -278,7 +278,7 @@ public:
    * @return A tensor representing the parameter tensor.
    */
   Tensor &value() {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return value_;
   }
 
@@ -287,7 +287,7 @@ public:
    * @return A tensor representing the gradient of the value.
    */
   const Tensor &gradient() const {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return grad_;
   }
 
@@ -296,7 +296,7 @@ public:
    * @return A tensor representing the gradient of the value.
    */
   Tensor &gradient() {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return grad_; }
 
   /**
@@ -305,7 +305,7 @@ public:
    * @return A tensor.
    */
   const Tensor &stats(const std::string &name) const {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return stats_.at(name);
   }
 
@@ -315,7 +315,7 @@ public:
    * @return A tensor.
    */
   Tensor &stats(const std::string &name) {
-    if (!valid()) THROW_ERROR("Invalid parameter.");
+    if (!valid()) PRIMITIV_THROW_ERROR("Invalid parameter.");
     return stats_.at(name);
   }
 

--- a/primitiv/shape.cc
+++ b/primitiv/shape.cc
@@ -8,7 +8,7 @@ namespace primitiv {
 Shape::Shape(std::initializer_list<std::uint32_t> dims, std::uint32_t batch)
 : depth_(0), batch_(batch), volume_(1) {
   if (dims.size() > MAX_DEPTH) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Exceeds dimension depth limit at Shape::Shape()."
         " depth: " << depth_ << " > MAX_DEPTH: " << MAX_DEPTH);
   }
@@ -18,14 +18,14 @@ Shape::Shape(std::initializer_list<std::uint32_t> dims, std::uint32_t batch)
   }
   while (depth_ > 0 && dims_[depth_ - 1] == 1) --depth_;
   if (volume_ == 0 || batch_ == 0) {
-    THROW_ERROR("Invalid shape: " << to_string());
+    PRIMITIV_THROW_ERROR("Invalid shape: " << to_string());
   }
 }
 
 Shape::Shape(const std::vector<std::uint32_t> &dims, std::uint32_t batch)
 : depth_(0), batch_(batch), volume_(1) {
   if (dims.size() > MAX_DEPTH) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Exceeds dimension depth limit at Shape::Shape()."
         " depth: " << depth_ << " > MAX_DEPTH: " << MAX_DEPTH);
   }
@@ -35,7 +35,7 @@ Shape::Shape(const std::vector<std::uint32_t> &dims, std::uint32_t batch)
   }
   while (depth_ > 0 && dims_[depth_ - 1] == 1) --depth_;
   if (volume_ == 0 || batch_ == 0) {
-    THROW_ERROR("Invalid shape: " << to_string());
+    PRIMITIV_THROW_ERROR("Invalid shape: " << to_string());
   }
 }
 
@@ -88,11 +88,11 @@ Shape Shape::resize_batch(std::uint32_t batch) const {
 
 void Shape::update_dim(std::uint32_t dim, std::uint32_t m) {
   if (dim >= MAX_DEPTH) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
       "Exceeds dimension depth limit at Shape::update_dim()."
       " dim: " << dim << " >= MAX_DEPTH: " << MAX_DEPTH);
   }
-  if (m == 0) THROW_ERROR("Could not set each dimension to 0.");
+  if (m == 0) PRIMITIV_THROW_ERROR("Could not set each dimension to 0.");
   if (dim >= depth_) {
     std::uint32_t new_depth = dim + 1;
     for (std::uint32_t i = depth_; i < new_depth; ++i) dims_[i] = 1;
@@ -104,7 +104,7 @@ void Shape::update_dim(std::uint32_t dim, std::uint32_t m) {
 }
 
 void Shape::update_batch(std::uint32_t batch) {
-  if (batch == 0) THROW_ERROR("Could not set the batch size to 0.");
+  if (batch == 0) PRIMITIV_THROW_ERROR("Could not set the batch size to 0.");
   batch_ = batch;
 }
 

--- a/primitiv/shape_ops.cc
+++ b/primitiv/shape_ops.cc
@@ -10,7 +10,7 @@ namespace shape_ops {
 Shape reshape(const Shape &before, const Shape &after) {
   if (before.volume() != after.volume() ||
       (after.has_batch() && after.batch() != before.batch())) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid shapes to reshape. before: " << before.to_string()
         << ", after: " << after.to_string());
   }
@@ -23,7 +23,7 @@ Shape flatten(const Shape &x) {
 
 Shape scalar_op(const Shape &x, const Shape &k) {
   if (!k.is_scalar() || !x.has_compatible_batch(k)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched for the scalar operation. "
         "x: " << x.to_string() << " != k: " << k.to_string());
   }
@@ -32,7 +32,7 @@ Shape scalar_op(const Shape &x, const Shape &k) {
 
 Shape elementwise(const Shape &a, const Shape &b) {
   if (!a.has_same_dims(b) || !a.has_compatible_batch(b)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Shape mismatched for the elementwise operation. "
         "a: " << a.to_string() << " != b: " << b.to_string());
   }
@@ -43,7 +43,7 @@ Shape slice(
     const Shape &x, std::uint32_t dim,
     std::uint32_t lower, std::uint32_t upper) {
   if (lower >= upper || upper > x[dim]) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid slice operation. shape: " << x.to_string()
         << ", dim: " << dim << ", lower: " << lower << ", upper: " << upper);
   }
@@ -60,7 +60,7 @@ Shape concat(const std::vector<Shape> &xs, std::uint32_t dim) {
 
 Shape concat(const std::vector<const Shape *> &xs, std::uint32_t dim) {
   if (xs.empty()) {
-    THROW_ERROR("No tensors to be concatenated.");
+    PRIMITIV_THROW_ERROR("No tensors to be concatenated.");
   }
 
   Shape s0 = *xs[0];
@@ -73,7 +73,7 @@ Shape concat(const std::vector<const Shape *> &xs, std::uint32_t dim) {
       for (std::uint32_t i = 1; i < xs.size(); ++i) {
         dims_str += ", " + xs[i]->to_string();
       }
-      THROW_ERROR("Invalid shapes to concatenate: " << dims_str);
+      PRIMITIV_THROW_ERROR("Invalid shapes to concatenate: " << dims_str);
     }
     if (!s0.has_batch()) s0.update_batch(s.batch());
     sum += s[dim];
@@ -85,7 +85,7 @@ Shape concat(const std::vector<const Shape *> &xs, std::uint32_t dim) {
 
 Shape broadcast(const Shape &x, std::uint32_t dim, std::uint32_t size) {
   if (x[dim] != 1 || size == 0) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid broadcasting. x: "
         << x.to_string() << ", dim: " << dim << ", size: " << size);
   }
@@ -97,13 +97,13 @@ Shape pick(
   const std::uint32_t n = x[dim];
   const std::uint32_t bi = ids.size();
   if (bi == 0 || (x.batch() != bi && x.has_batch() && bi > 1)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid IDs to pick. shape: " << x.to_string()
         << ", ids.size(): " << ids.size());
   }
   for (std::uint32_t i = 0; i < bi; ++i) {
     if (ids[i] >= n) {
-      THROW_ERROR(
+      PRIMITIV_THROW_ERROR(
           "Invalid IDs to pick. shape: " << x.to_string()
           << ", ids[" << i << "]: " << ids[i]);
     }
@@ -116,7 +116,7 @@ Shape pick(
 
 Shape transpose(const Shape &x) {
   if (!x.is_matrix()) {
-    THROW_ERROR("Invalid shape to transpose: " << x.to_string());
+    PRIMITIV_THROW_ERROR("Invalid shape to transpose: " << x.to_string());
   }
   return Shape({x[1], x[0]}, x.batch());
 }
@@ -124,7 +124,7 @@ Shape transpose(const Shape &x) {
 Shape matmul(const Shape &l, const Shape &r) {
   if (!l.is_matrix() || !r.is_matrix() || l[1] != r[0] ||
       !l.has_compatible_batch(r)) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid shapes to calculate the matrix product: "
         << l.to_string() << ", " << r.to_string());
   }
@@ -146,7 +146,7 @@ Shape conv2d(
       !x.has_compatible_batch(w) ||
       stride0 == 0 || stride1 == 0 ||
       dilation0 == 0 || dilation1 == 0) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid arguments to calculate a convolution: "
         << x.to_string() << ", " << w.to_string() << ", "
         << padding0 << ", " << padding1 << ", "
@@ -170,7 +170,7 @@ Shape pool2d(
       x0 < window0 || x1 < window1 ||
       window0 == 0 || window1 == 0 ||
       stride0 == 0 || stride1 == 0) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Invalid arguments to calculate a pooling: "
         << x.to_string() << ", "
         << window0 << ", " << window1 << ", "

--- a/primitiv/tensor.cc
+++ b/primitiv/tensor.cc
@@ -9,7 +9,7 @@ namespace primitiv {
 float Tensor::to_float() const {
   check_valid();
   if (shape_.size() != 1) {
-    THROW_ERROR(
+    PRIMITIV_THROW_ERROR(
         "Tensor has more than 1 values. shape = " << shape_.to_string());
   }
   return device_->tensor_to_vector(*this)[0];

--- a/primitiv/tensor.h
+++ b/primitiv/tensor.h
@@ -58,7 +58,7 @@ public:
    */
   void check_valid() const {
     if (!valid()) {
-      THROW_ERROR("Invalid Tensor object.");
+      PRIMITIV_THROW_ERROR("Invalid Tensor object.");
     }
   }
 

--- a/primitiv/tensor_funcs.cc
+++ b/primitiv/tensor_funcs.cc
@@ -153,7 +153,7 @@ Tensor slice(const Tensor &x, std::uint32_t dim, std::uint32_t lower, std::uint3
 
 template<>
 Tensor concat(const std::vector<const Tensor *> &xs, std::uint32_t dim) {
-  if (xs.empty()) THROW_ERROR("No tensors to be concatenated.");
+  if (xs.empty()) PRIMITIV_THROW_ERROR("No tensors to be concatenated.");
   return xs[0]->device().concat_fw(xs, dim);
 }
 

--- a/test/cuda_memory_pool_test.cc
+++ b/test/cuda_memory_pool_test.cc
@@ -3,7 +3,7 @@
 #include <gtest/gtest.h>
 #include <primitiv/memory_pool.h>
 #include <primitiv/cuda_device.h>
-#include <primitiv/cuda_utils.h>
+#include <primitiv/internal/cuda_utils.h>
 #include <primitiv/error.h>
 #include <primitiv/shape.h>
 

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -67,14 +67,15 @@ TEST_F(TensorForwardTest, CheckCopy) {
   for (Device *dev : devices) {
     for (Device *dev2 : devices) {
       // Sets different (count-up) data to be copied every time.
-      std::generate(data.begin(), data.end(), [&]() { i += 1; return i; });
+      std::generate(data.begin(), data.end(), [&]() { return ++i; });
       for (float x : data) std::cout << x << ' ';
       std::cout << std::endl;
 
       const Tensor x = dev->new_tensor_by_vector(Shape({2, 2}, 3), data);
       const Tensor y = copy(x, *dev2);
       EXPECT_EQ(Shape({2, 2}, 3), y.shape());
-      EXPECT_TRUE(vector_match(data, y.to_vector()));
+      EXPECT_TRUE(vector_match_ulps(
+            data, y.to_vector(), get_default_ulps(*dev2)));
     }
   }
 }


### PR DESCRIPTION
This branch adds `PRIMITIV_` prefix to all exported macros, and separate `cuda_utils.h/cu` to the `internal` directory to enhance independency with other libraries.