### PR TITLE
Use distribution's Eigen on Travis CI

### DIFF
--- a/.travis/fedora.sh
+++ b/.travis/fedora.sh
@@ -7,23 +7,7 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td fedora:latest /bi
 
 # install
 docker exec travis-ci bash -c "dnf update -y"
-docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel"
-
-# install Eigen
-#
-# NOTE(vbkaisetsu):
-# Fedora 27 contains Eigen 3.3.4 and gcc 7.2.1.
-# gcc/g++ 7 detects int-in-bool-context error in the latest released version of Eigen
-# by default, and it will be fixed in 3.3.5. For now, this script downloads the latest
-# development version to solve this problem.
-#
-# For more details, see: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1402
-#
-docker exec travis-ci bash -c "dnf install -y mercurial"
-docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
-docker exec travis-ci bash -c "mkdir ./eigen/build"
-docker exec travis-ci bash -c "cd ./eigen/build && cmake .."
-docker exec travis-ci bash -c "cd ./eigen/build && make && make install"
+docker exec travis-ci bash -c "dnf install -y rpm-build gcc-c++ cmake gtest-devel eigen3-devel"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "dnf install -y opencl-headers git hwloc-devel libtool-ltdl-devel ocl-icd-devel ocl-icd clang llvm-devel clang-devel zlib-devel blas-devel boost-devel patch --setopt=install_weak_deps=False"

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -7,23 +7,7 @@ docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td ubuntu:rolling /b
 
 # install
 docker exec travis-ci bash -c "apt update"
-docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
-
-# install Eigen
-#
-# NOTE(vbkaisetsu):
-# Ubuntu 17.04  contains Eigen 3.3.4 and gcc 7.2.0.
-# gcc/g++ 7 detects int-in-bool-context error in the latest released version of Eigen
-# by default, and it will be fixed in 3.3.5. For now, this script downloads the latest
-# development version to solve this problem.
-#
-# For more details, see: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1402
-#
-docker exec travis-ci bash -c "apt install -y mercurial"
-docker exec travis-ci bash -c "hg clone https://bitbucket.org/eigen/eigen"
-docker exec travis-ci bash -c "mkdir ./eigen/build"
-docker exec travis-ci bash -c "cd ./eigen/build && cmake .."
-docker exec travis-ci bash -c "cd ./eigen/build && make && make install"
+docker exec travis-ci bash -c "apt install -y build-essential cmake googletest libeigen3-dev"
 
 # install OpenCL environment
 docker exec travis-ci bash -c "apt install -y opencl-headers libclblas-dev git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-3.8 llvm-3.8-dev libclang-3.8-dev libz-dev"


### PR DESCRIPTION
*primitiv* is compiled with`-Wno-int-in-bool-context` now, so this branch uses distribution's Eigen in Ubuntu and Fedora on Travis CI.