### PR TITLE
Add CLBlast include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if(PRIMITIV_USE_CUDA)
 endif()
 if(PRIMITIV_USE_OPENCL)
   include_directories(${CLHPP_INCLUDE_DIR})
+  include_directories(${CLBLAST_INCLUDE_DIR})
 endif()
 
 # core library


### PR DESCRIPTION
This branch adds a missing include directory to CMakeLists.