### PR TITLE
Disable x86 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ matrix:
       services: docker
     - os: osx
       env: SCRIPT=osx
-    - os: linux
-      env: SCRIPT=debian-x86
-      services: docker
+    # FIXME(vbkaisetsu):
+    # The x86 support is currently unstable and test cases sometimes be failed.
+    # I temporally disable this test.
+    #- os: linux
+      #env: SCRIPT=debian-x86
+      #services: docker
 
 script:
   - $TRAVIS_BUILD_DIR/.travis/${SCRIPT}.sh


### PR DESCRIPTION
This branch disables x86 tests on Travis CI.
The x86 support is currently unstable due to the 80-bit floating point problem.