### PR TITLE
Add max() and min() functions

### DIFF
--- a/primitiv/basic_functions.h
+++ b/primitiv/basic_functions.h
@@ -697,6 +697,66 @@ template<typename Var>
 type_traits::Identity<Var> elu(const Var &x, float a);
 
 /**
+ * Retrieves maximum values along an axis.
+ * Following examples show how this function work:
+ * @f[
+ *  \begin{array}{lcl}
+ *    x & := &
+ *      \left( \begin{array}{ccc}
+ *        1 & 6 & 7 \\ 2 & 5 & 9 \\ 3 & 4 & 8
+ *      \end{array} \right), \\
+ *    \mathrm{max}(x, 0) & = &
+ *      \left( \begin{array}{ccc}
+ *        3 & 6 & 9
+ *      \end{array} \right), \\
+ *    \mathrm{max}(x, 1) & = &
+ *      \left( \begin{array}{c}
+ *        7 \\ 9 \\ 8
+ *      \end{array} \right), \\
+ *    \mathrm{max}(x, 2) & = &
+ *      \left( \begin{array}{ccc}
+ *        1 & 6 & 7 \\ 2 & 5 & 9 \\ 3 & 4 & 8
+ *      \end{array} \right).
+ *  \end{array}
+ * @f]
+ * @param x A variable representing values before reduction.
+ * @param dim Axis to be processed.
+ * @return A new variable.
+ */
+template<typename Var>
+type_traits::Identity<Var> max(const Var &x, std::uint32_t dim);
+
+/**
+ * Retrieves minimum values along an axis.
+ * Following examples show how this function work:
+ * @f[
+ *  \begin{array}{lcl}
+ *    x & := &
+ *      \left( \begin{array}{ccc}
+ *        1 & 6 & 7 \\ 2 & 5 & 9 \\ 3 & 4 & 8
+ *      \end{array} \right), \\
+ *    \mathrm{min}(x, 0) & = &
+ *      \left( \begin{array}{ccc}
+ *        1 & 4 & 7
+ *      \end{array} \right), \\
+ *    \mathrm{min}(x, 1) & = &
+ *      \left( \begin{array}{c}
+ *        1 \\ 2 \\ 3
+ *      \end{array} \right), \\
+ *    \mathrm{min}(x, 2) & = &
+ *      \left( \begin{array}{ccc}
+ *        1 & 6 & 7 \\ 2 & 5 & 9 \\ 3 & 4 & 8
+ *      \end{array} \right).
+ *  \end{array}
+ * @f]
+ * @param x A variable representing values before reduction.
+ * @param dim Axis to be processed.
+ * @return A new variable.
+ */
+template<typename Var>
+type_traits::Identity<Var> min(const Var &x, std::uint32_t dim);
+
+/**
  * Applies summation along an axis.
  * Following examples show how this function work:
  * @f[

--- a/primitiv/c/functions.cc
+++ b/primitiv/c/functions.cc
@@ -346,6 +346,38 @@ PRIMITIV_C_STATUS primitivTensoRelu(
   return PRIMITIV_C_OK;
 } PRIMITIV_C_HANDLE_EXCEPTIONS
 
+PRIMITIV_C_STATUS primitivApplyNodeMax(
+    const primitivNode_t *x, uint32_t dim, primitivNode_t **y) try {
+  PRIMITIV_C_CHECK_NOT_NULL(x);
+  PRIMITIV_C_CHECK_NOT_NULL(y);
+  *y = to_c_ptr_from_value(primitiv::functions::max(*to_cpp_ptr(x), dim));
+  return PRIMITIV_C_OK;
+} PRIMITIV_C_HANDLE_EXCEPTIONS
+
+PRIMITIV_C_STATUS primitivApplyTensorMax(
+    const primitivTensor_t *x, uint32_t dim, primitivTensor_t **y) try {
+  PRIMITIV_C_CHECK_NOT_NULL(x);
+  PRIMITIV_C_CHECK_NOT_NULL(y);
+  *y = to_c_ptr_from_value(primitiv::functions::max(*to_cpp_ptr(x), dim));
+  return PRIMITIV_C_OK;
+} PRIMITIV_C_HANDLE_EXCEPTIONS
+
+PRIMITIV_C_STATUS primitivApplyNodeMin(
+    const primitivNode_t *x, uint32_t dim, primitivNode_t **y) try {
+  PRIMITIV_C_CHECK_NOT_NULL(x);
+  PRIMITIV_C_CHECK_NOT_NULL(y);
+  *y = to_c_ptr_from_value(primitiv::functions::min(*to_cpp_ptr(x), dim));
+  return PRIMITIV_C_OK;
+} PRIMITIV_C_HANDLE_EXCEPTIONS
+
+PRIMITIV_C_STATUS primitivApplyTensorMin(
+    const primitivTensor_t *x, uint32_t dim, primitivTensor_t **y) try {
+  PRIMITIV_C_CHECK_NOT_NULL(x);
+  PRIMITIV_C_CHECK_NOT_NULL(y);
+  *y = to_c_ptr_from_value(primitiv::functions::min(*to_cpp_ptr(x), dim));
+  return PRIMITIV_C_OK;
+} PRIMITIV_C_HANDLE_EXCEPTIONS
+
 PRIMITIV_C_STATUS primitivApplyNodeSum(
     const primitivNode_t *x, uint32_t dim, primitivNode_t **y) try {
   PRIMITIV_C_CHECK_NOT_NULL(x);

--- a/primitiv/c/functions.h
+++ b/primitiv/c/functions.h
@@ -127,6 +127,16 @@ PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyNodeElu(
 PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorElu(
     const primitivTensor_t *x, float a, primitivTensor_t **y);
 
+PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyNodeMax(
+    const primitivNode_t *x, uint32_t dim, primitivNode_t **y);
+PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorMax(
+    const primitivTensor_t *x, uint32_t dim, primitivTensor_t **y);
+
+PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyNodeMin(
+    const primitivNode_t *x, uint32_t dim, primitivNode_t **y);
+PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorMin(
+    const primitivTensor_t *x, uint32_t dim, primitivTensor_t **y);
+
 PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyNodeSum(
     const primitivNode_t *x, uint32_t dim, primitivNode_t **y);
 PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorSum(

--- a/primitiv/cuda16_device.h
+++ b/primitiv/cuda16_device.h
@@ -176,6 +176,11 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
+  void max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+  void min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+
   void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;

--- a/primitiv/cuda_device.h
+++ b/primitiv/cuda_device.h
@@ -174,6 +174,11 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
+  void max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+  void min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+
   void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;

--- a/primitiv/device.cc
+++ b/primitiv/device.cc
@@ -490,6 +490,56 @@ void Device::max_pool2d_bw(
 #undef DEV_FW_AB
 #undef DEV_BW_AB
 
+Tensor Device::max_fw(const Tensor &x, std::uint32_t dim) {
+  CHECK_DEVICE(x);
+  Tensor y = new_raw_tensor(x.shape().resize_dim(dim, 1));
+  max_fw_impl(x, dim, y);
+  return y;
+}
+
+Tensor Device::min_fw(const Tensor &x, std::uint32_t dim) {
+  CHECK_DEVICE(x);
+  Tensor y = new_raw_tensor(x.shape().resize_dim(dim, 1));
+  min_fw_impl(x, dim, y);
+  return y;
+}
+
+void Device::max_bw(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) {
+  CHECK_DEVICE(x);
+  CHECK_DEVICE(y);
+  CHECK_DEVICE(gy);
+  CHECK_DEVICE(gx);
+  const Shape &r = x.shape();
+  const Shape s = r.resize_dim(dim, 1);
+  if (gx.shape() != r || y.shape() != s || gy.shape() != s) {
+    PRIMITIV_THROW_ERROR(
+        "Shape mismatched at max_bw(dim=" << dim << ")"
+        << ". x.shape: " << r.to_string()
+        << ", y.shape: " << y.shape().to_string()
+        << ", gy.shape: " << gy.shape().to_string()
+        << ", gx.shape: " << gx.shape().to_string());
+  }
+  max_bw_impl(x, y, gy, dim, gx);
+}
+
+void Device::min_bw(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) {
+  CHECK_DEVICE(x);
+  CHECK_DEVICE(y);
+  CHECK_DEVICE(gy);
+  CHECK_DEVICE(gx);
+  const Shape &r = x.shape();
+  const Shape s = r.resize_dim(dim, 1);
+  if (gx.shape() != r || y.shape() != s || gy.shape() != s) {
+    PRIMITIV_THROW_ERROR(
+        "Shape mismatched at min_bw(dim=" << dim << ")"
+        << ". x.shape: " << r.to_string()
+        << ", y.shape: " << y.shape().to_string()
+        << ", gy.shape: " << gy.shape().to_string()
+        << ", gx.shape: " << gx.shape().to_string());
+  }
+  min_bw_impl(x, y, gy, dim, gx);
+}
+
 Tensor Device::sum_fw(const Tensor &x, std::uint32_t dim) {
   CHECK_DEVICE(x);
   Tensor y = new_raw_tensor(x.shape().resize_dim(dim, 1));

--- a/primitiv/device.h
+++ b/primitiv/device.h
@@ -205,6 +205,11 @@ public:
       Tensor &ga, Tensor &gb);
 
   // Dimension operations.
+  Tensor max_fw(const Tensor &x, std::uint32_t dim);
+  Tensor min_fw(const Tensor &x, std::uint32_t dim);
+  void max_bw(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx);
+  void min_bw(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx);
+
   Tensor sum_fw(const Tensor &x, std::uint32_t dim);
   Tensor logsumexp_fw(const Tensor &x, std::uint32_t dim);
   Tensor broadcast_fw(const Tensor &x, std::uint32_t dim, std::uint32_t size);
@@ -450,6 +455,11 @@ private:
   virtual void matmul_bw_impl(
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) = 0;
+
+  virtual void max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) = 0;
+  virtual void min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) = 0;
+  virtual void max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) = 0;
+  virtual void min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) = 0;
 
   virtual void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) = 0;
   virtual void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) = 0;

--- a/primitiv/device_ops/cuda/argmax.cu
+++ b/primitiv/device_ops/cuda/argmax.cu
@@ -26,7 +26,9 @@ __global__ void argmax_dev(
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (max_val[tid + k] > max_val[tid]) { \
+      if (max_val[tid + k] > max_val[tid] \
+          || (max_val[tid + k] == max_val[tid] \
+              && argmax_val[tid + k] < argmax_val[tid])) { \
         max_val[tid] = max_val[tid + k]; \
         argmax_val[tid] = argmax_val[tid + k]; \
       } \

--- a/primitiv/device_ops/cuda/argmin.cu
+++ b/primitiv/device_ops/cuda/argmin.cu
@@ -26,7 +26,9 @@ __global__ void argmin_dev(
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (min_val[tid + k] < min_val[tid]) { \
+      if (min_val[tid + k] < min_val[tid] \
+          || (min_val[tid + k] == min_val[tid] \
+              && argmin_val[tid + k] < argmin_val[tid])) { \
         min_val[tid] = min_val[tid + k]; \
         argmin_val[tid] = argmin_val[tid + k]; \
       } \

--- a/primitiv/device_ops/cuda/max.cu
+++ b/primitiv/device_ops/cuda/max.cu
@@ -13,10 +13,11 @@ __global__ void max_fw_dev(
   const std::uint32_t bid = blockIdx.x;
   const std::uint32_t tid = threadIdx.x;
   px += bid % skip + (bid / skip) * skip * n;
-  temp[tid] = FLOAT_NEGATIVE_INFINITY;
+  float thread_max = FLOAT_NEGATIVE_INFINITY;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    temp[tid] = fmaxf(px[i * skip], temp[tid]);
+    thread_max = fmaxf(px[i * skip], thread_max);
   }
+  temp[tid] = thread_max;
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
@@ -47,13 +48,13 @@ __global__ void max_bw_dev(
   const float max_val = py[bid];
   px += bid % skip + (bid / skip) * skip * n;
   pgx += bid % skip + (bid / skip) * skip * n;
-  argmax_val[tid] = n;
+  std::uint32_t thread_argmax = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    argmax_val[tid]
-        = px[i * skip] == max_val
-        ? min(i, argmax_val[tid])
-        : argmax_val[tid];
+    if (px[i * skip] == max_val) {
+      thread_argmax = min(i, thread_argmax);
+    }
   }
+  argmax_val[tid] = thread_argmax;
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \

--- a/primitiv/device_ops/cuda/max.cu
+++ b/primitiv/device_ops/cuda/max.cu
@@ -49,10 +49,10 @@ __global__ void max_bw_dev(
   pgx += bid % skip + (bid / skip) * skip * n;
   argmax_val[tid] = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    if (px[i * skip] == py[bid]) {
-      argmax_val[tid] = i;
-      break;
-    }
+    argmax_val[tid]
+        = px[i * skip] == max_val
+        ? min(i, argmax_val[tid])
+        : argmax_val[tid];
   }
   ::__syncthreads();
 #define REDUCE(k) \

--- a/primitiv/device_ops/cuda/max.cu
+++ b/primitiv/device_ops/cuda/max.cu
@@ -1,0 +1,150 @@
+#include <primitiv/config.h>
+
+#include <primitiv/cuda_device.h>
+#include <primitiv/internal/cuda_utils.h>
+#include <primitiv/device_ops/cuda/common.h>
+
+namespace {
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void max_fw_dev(
+    const float *px, std::uint32_t skip, std::uint32_t n, float *py) {
+  __shared__ float temp[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  temp[tid] = FLOAT_NEGATIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = px[i * skip];
+    if (val > temp[tid]) {
+      temp[tid] = val;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (temp[tid + k] > temp[tid]) { \
+        temp[tid] = temp[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  if (tid == 0) py[bid] = temp[0];
+}
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void max_bw_dev(
+    const float *px, const float *py, const float *pgy,
+    std::uint32_t skip, std::uint32_t n, float *pgx) {
+  __shared__ float max_val[BLOCK_SIZE];
+  __shared__ std::uint32_t argmax_val[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  pgx += bid % skip + (bid / skip) * skip * n;
+  max_val[tid] = FLOAT_NEGATIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = px[i * skip];
+    if (val > max_val[tid]) {
+      max_val[tid] = val;
+      argmax_val[tid] = i;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (max_val[tid + k] > max_val[tid] \
+          || (max_val[tid + k] == max_val[tid] \
+              && argmax_val[tid + k] < argmax_val[tid])) { \
+        max_val[tid] = max_val[tid + k]; \
+        argmax_val[tid] = argmax_val[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  if (tid == 0) pgx[argmax_val[0] * skip] += pgy[bid];
+}
+
+}  // namespace
+
+namespace primitiv {
+namespace devices {
+
+void CUDA::max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: ::max_fw_dev<k><<<r, k>>>(CDATA(x), s, n, MDATA(y)); break
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+void CUDA::max_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: ::max_bw_dev<k><<<r, k>>>(CDATA(x), CDATA(y), CDATA(gy), s, n, MDATA(gx)); break
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/cuda/min.cu
+++ b/primitiv/device_ops/cuda/min.cu
@@ -49,10 +49,10 @@ __global__ void min_bw_dev(
   pgx += bid % skip + (bid / skip) * skip * n;
   argmin_val[tid] = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    if (px[i * skip] == py[bid]) {
-      argmin_val[tid] = i;
-      break;
-    }
+    argmin_val[tid]
+        = px[i * skip] == min_val
+        ? min(i, argmin_val[tid])
+        : argmin_val[tid];
   }
   ::__syncthreads();
 #define REDUCE(k) \

--- a/primitiv/device_ops/cuda/min.cu
+++ b/primitiv/device_ops/cuda/min.cu
@@ -13,10 +13,11 @@ __global__ void min_fw_dev(
   const std::uint32_t bid = blockIdx.x;
   const std::uint32_t tid = threadIdx.x;
   px += bid % skip + (bid / skip) * skip * n;
-  temp[tid] = FLOAT_POSITIVE_INFINITY;
+  float thread_min = FLOAT_POSITIVE_INFINITY;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    temp[tid] = fminf(px[i * skip], temp[tid]);
+    thread_min = fminf(px[i * skip], thread_min);
   }
+  temp[tid] = thread_min;
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
@@ -47,13 +48,13 @@ __global__ void min_bw_dev(
   const float min_val = py[bid];
   px += bid % skip + (bid / skip) * skip * n;
   pgx += bid % skip + (bid / skip) * skip * n;
-  argmin_val[tid] = n;
+  std::uint32_t thread_argmin = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    argmin_val[tid]
-        = px[i * skip] == min_val
-        ? min(i, argmin_val[tid])
-        : argmin_val[tid];
+    if (px[i * skip] == min_val) {
+      thread_argmin = min(i, thread_argmin);
+    }
   }
+  argmin_val[tid] = thread_argmin;
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \

--- a/primitiv/device_ops/cuda/min.cu
+++ b/primitiv/device_ops/cuda/min.cu
@@ -15,19 +15,12 @@ __global__ void min_fw_dev(
   px += bid % skip + (bid / skip) * skip * n;
   temp[tid] = FLOAT_POSITIVE_INFINITY;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    const float val = px[i * skip];
-    if (val < temp[tid]) {
-      temp[tid] = val;
-    }
+    temp[tid] = fminf(px[i * skip], temp[tid]);
   }
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
-    if (tid < k) { \
-      if (temp[tid + k] < temp[tid]) { \
-        temp[tid] = temp[tid + k]; \
-      } \
-    } \
+    if (tid < k) temp[tid] = fminf(temp[tid + k], temp[tid]); \
     ::__syncthreads(); \
   }
   REDUCE(512)
@@ -51,6 +44,7 @@ __global__ void min_bw_dev(
   __shared__ std::uint32_t argmin_val[BLOCK_SIZE];
   const std::uint32_t bid = blockIdx.x;
   const std::uint32_t tid = threadIdx.x;
+  const float min_val = py[bid];
   px += bid % skip + (bid / skip) * skip * n;
   pgx += bid % skip + (bid / skip) * skip * n;
   argmin_val[tid] = n;
@@ -63,11 +57,7 @@ __global__ void min_bw_dev(
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
-    if (tid < k) { \
-      if (argmin_val[tid + k] < argmin_val[tid]) { \
-        argmin_val[tid] = argmin_val[tid + k]; \
-      } \
-    } \
+    if (tid < k) argmin_val[tid] = min(argmin_val[tid + k], argmin_val[tid]); \
     ::__syncthreads(); \
   }
   REDUCE(512)

--- a/primitiv/device_ops/cuda/min.cu
+++ b/primitiv/device_ops/cuda/min.cu
@@ -1,0 +1,150 @@
+#include <primitiv/config.h>
+
+#include <primitiv/cuda_device.h>
+#include <primitiv/internal/cuda_utils.h>
+#include <primitiv/device_ops/cuda/common.h>
+
+namespace {
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void min_fw_dev(
+    const float *px, std::uint32_t skip, std::uint32_t n, float *py) {
+  __shared__ float temp[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  temp[tid] = FLOAT_POSITIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = px[i * skip];
+    if (val < temp[tid]) {
+      temp[tid] = val;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (temp[tid + k] < temp[tid]) { \
+        temp[tid] = temp[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  if (tid == 0) py[bid] = temp[0];
+}
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void min_bw_dev(
+    const float *px, const float *py, const float *pgy,
+    std::uint32_t skip, std::uint32_t n, float *pgx) {
+  __shared__ float min_val[BLOCK_SIZE];
+  __shared__ std::uint32_t argmin_val[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  pgx += bid % skip + (bid / skip) * skip * n;
+  min_val[tid] = FLOAT_POSITIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = px[i * skip];
+    if (val < min_val[tid]) {
+      min_val[tid] = val;
+      argmin_val[tid] = i;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (min_val[tid + k] < min_val[tid] \
+          || (min_val[tid + k] == min_val[tid] \
+              && argmin_val[tid + k] < argmin_val[tid])) { \
+        min_val[tid] = min_val[tid + k]; \
+        argmin_val[tid] = argmin_val[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  if (tid == 0) pgx[argmin_val[0] * skip] += pgy[bid];
+}
+
+}  // namespace
+
+namespace primitiv {
+namespace devices {
+
+void CUDA::min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: ::min_fw_dev<k><<<r, k>>>(CDATA(x), s, n, MDATA(y)); break
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+void CUDA::min_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: ::min_bw_dev<k><<<r, k>>>(CDATA(x), CDATA(y), CDATA(gy), s, n, MDATA(gx)); break
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/cuda16/argmax.cu
+++ b/primitiv/device_ops/cuda16/argmax.cu
@@ -26,7 +26,9 @@ __global__ void argmax_dev(
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (max_val[tid + k] > max_val[tid]) { \
+      if (max_val[tid + k] > max_val[tid] \
+          || (max_val[tid + k] == max_val[tid] \
+              && argmax_val[tid + k] < argmax_val[tid])) { \
         max_val[tid] = max_val[tid + k]; \
         argmax_val[tid] = argmax_val[tid + k]; \
       } \

--- a/primitiv/device_ops/cuda16/argmin.cu
+++ b/primitiv/device_ops/cuda16/argmin.cu
@@ -26,7 +26,9 @@ __global__ void argmin_dev(
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (min_val[tid + k] < min_val[tid]) { \
+      if (min_val[tid + k] < min_val[tid] \
+          || (min_val[tid + k] == min_val[tid] \
+              && argmin_val[tid + k] < argmin_val[tid])) { \
         min_val[tid] = min_val[tid + k]; \
         argmin_val[tid] = argmin_val[tid + k]; \
       } \

--- a/primitiv/device_ops/cuda16/max.cu
+++ b/primitiv/device_ops/cuda16/max.cu
@@ -1,0 +1,158 @@
+#include <primitiv/config.h>
+
+#include <primitiv/cuda16_device.h>
+#include <primitiv/internal/cuda_utils.h>
+#include <primitiv/device_ops/cuda16/common.h>
+
+namespace {
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void max_fw_dev(
+    const half *px, std::uint32_t skip, std::uint32_t n, half *py) {
+  __shared__ float temp[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  temp[tid] = FLOAT_NEGATIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = ::__half2float(px[i * skip]);
+    if (val > temp[tid]) {
+      temp[tid] = val;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (temp[tid + k] > temp[tid]) { \
+        temp[tid] = temp[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  if (tid == 0) py[bid] = ::__float2half(temp[0]);
+}
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void max_bw_dev(
+    const half *px, const half *py, const half *pgy,
+    std::uint32_t skip, std::uint32_t n, half *pgx) {
+  __shared__ float max_val[BLOCK_SIZE];
+  __shared__ std::uint32_t argmax_val[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  pgx += bid % skip + (bid / skip) * skip * n;
+  max_val[tid] = FLOAT_NEGATIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = ::__half2float(px[i * skip]);
+    if (val > max_val[tid]) {
+      max_val[tid] = val;
+      argmax_val[tid] = i;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (max_val[tid + k] > max_val[tid] \
+          || (max_val[tid + k] == max_val[tid] \
+              && argmax_val[tid + k] < argmax_val[tid])) { \
+        max_val[tid] = max_val[tid + k]; \
+        argmax_val[tid] = argmax_val[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  const float pgxf = ::__half2float(pgx[argmax_val[0] * skip]);
+  const float pgyf = ::__half2float(pgy[bid]);
+  if (tid == 0) pgx[argmax_val[0] * skip] = ::__float2half(pgxf + pgyf);
+}
+
+}  // namespace
+
+namespace primitiv {
+namespace devices {
+
+void CUDA16::max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: \
+      ::max_fw_dev<k><<<r, k>>>(CDATA(half, x), s, n, MDATA(half, y)); \
+      break;
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+void CUDA16::max_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: \
+      ::max_bw_dev<k><<<r, k>>>( \
+          CDATA(half, x), CDATA(half, y), CDATA(half, gy), \
+          s, n, MDATA(half, gx)); \
+      break;
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/cuda16/max.cu
+++ b/primitiv/device_ops/cuda16/max.cu
@@ -48,28 +48,24 @@ template<std::uint32_t BLOCK_SIZE>
 __global__ void max_bw_dev(
     const half *px, const half *py, const half *pgy,
     std::uint32_t skip, std::uint32_t n, half *pgx) {
-  __shared__ float max_val[BLOCK_SIZE];
   __shared__ std::uint32_t argmax_val[BLOCK_SIZE];
   const std::uint32_t bid = blockIdx.x;
   const std::uint32_t tid = threadIdx.x;
   px += bid % skip + (bid / skip) * skip * n;
   pgx += bid % skip + (bid / skip) * skip * n;
-  max_val[tid] = FLOAT_NEGATIVE_INFINITY;
+  argmax_val[tid] = n;
+  const float max_val = ::__half2float(py[bid]);
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    const float val = ::__half2float(px[i * skip]);
-    if (val > max_val[tid]) {
-      max_val[tid] = val;
+    if (::__half2float(px[i * skip]) == max_val) {
       argmax_val[tid] = i;
+      break;
     }
   }
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (max_val[tid + k] > max_val[tid] \
-          || (max_val[tid + k] == max_val[tid] \
-              && argmax_val[tid + k] < argmax_val[tid])) { \
-        max_val[tid] = max_val[tid + k]; \
+      if (argmax_val[tid + k] < argmax_val[tid]) { \
         argmax_val[tid] = argmax_val[tid + k]; \
       } \
     } \

--- a/primitiv/device_ops/cuda16/max.cu
+++ b/primitiv/device_ops/cuda16/max.cu
@@ -13,10 +13,11 @@ __global__ void max_fw_dev(
   const std::uint32_t bid = blockIdx.x;
   const std::uint32_t tid = threadIdx.x;
   px += bid % skip + (bid / skip) * skip * n;
-  temp[tid] = FLOAT_NEGATIVE_INFINITY;
+  float thread_max = FLOAT_NEGATIVE_INFINITY;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    temp[tid] = fmaxf(::__half2float(px[i * skip]), temp[tid]);
+    thread_max = fmaxf(::__half2float(px[i * skip]), thread_max);
   }
+  temp[tid] = thread_max;
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
@@ -47,13 +48,13 @@ __global__ void max_bw_dev(
   const float max_val = ::__half2float(py[bid]);
   px += bid % skip + (bid / skip) * skip * n;
   pgx += bid % skip + (bid / skip) * skip * n;
-  argmax_val[tid] = n;
+  std::uint32_t thread_argmin = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    argmax_val[tid]
-        = ::__half2float(px[i * skip]) == max_val
-        ? min(i, argmax_val[tid])
-        : argmax_val[tid];
+    if (::__half2float(px[i * skip]) == max_val) {
+      thread_argmin = min(i, thread_argmin);
+    }
   }
+  argmax_val[tid] = thread_argmin;
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \

--- a/primitiv/device_ops/cuda16/max.cu
+++ b/primitiv/device_ops/cuda16/max.cu
@@ -15,19 +15,12 @@ __global__ void max_fw_dev(
   px += bid % skip + (bid / skip) * skip * n;
   temp[tid] = FLOAT_NEGATIVE_INFINITY;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    const float val = ::__half2float(px[i * skip]);
-    if (val > temp[tid]) {
-      temp[tid] = val;
-    }
+    temp[tid] = fmaxf(::__half2float(px[i * skip]), temp[tid]);
   }
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
-    if (tid < k) { \
-      if (temp[tid + k] > temp[tid]) { \
-        temp[tid] = temp[tid + k]; \
-      } \
-    } \
+    if (tid < k) temp[tid] = fmaxf(temp[tid + k], temp[tid]); \
     ::__syncthreads(); \
   }
   REDUCE(512)
@@ -51,10 +44,10 @@ __global__ void max_bw_dev(
   __shared__ std::uint32_t argmax_val[BLOCK_SIZE];
   const std::uint32_t bid = blockIdx.x;
   const std::uint32_t tid = threadIdx.x;
+  const float max_val = ::__half2float(py[bid]);
   px += bid % skip + (bid / skip) * skip * n;
   pgx += bid % skip + (bid / skip) * skip * n;
   argmax_val[tid] = n;
-  const float max_val = ::__half2float(py[bid]);
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
     if (::__half2float(px[i * skip]) == max_val) {
       argmax_val[tid] = i;
@@ -64,11 +57,7 @@ __global__ void max_bw_dev(
   ::__syncthreads();
 #define REDUCE(k) \
   if (BLOCK_SIZE >= k << 1) { \
-    if (tid < k) { \
-      if (argmax_val[tid + k] < argmax_val[tid]) { \
-        argmax_val[tid] = argmax_val[tid + k]; \
-      } \
-    } \
+    if (tid < k) argmax_val[tid] = min(argmax_val[tid + k], argmax_val[tid]); \
     ::__syncthreads(); \
   }
   REDUCE(512)

--- a/primitiv/device_ops/cuda16/max.cu
+++ b/primitiv/device_ops/cuda16/max.cu
@@ -86,9 +86,7 @@ __global__ void max_bw_dev(
   REDUCE(2)
   REDUCE(1)
 #undef REDUCE
-  const float pgxf = ::__half2float(pgx[argmax_val[0] * skip]);
-  const float pgyf = ::__half2float(pgy[bid]);
-  if (tid == 0) pgx[argmax_val[0] * skip] = ::__float2half(pgxf + pgyf);
+  if (tid == 0) INPLACE_ADD(pgx + argmax_val[0] * skip, ::__half2float(pgy[bid]));
 }
 
 }  // namespace

--- a/primitiv/device_ops/cuda16/max.cu
+++ b/primitiv/device_ops/cuda16/max.cu
@@ -49,10 +49,10 @@ __global__ void max_bw_dev(
   pgx += bid % skip + (bid / skip) * skip * n;
   argmax_val[tid] = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    if (::__half2float(px[i * skip]) == max_val) {
-      argmax_val[tid] = i;
-      break;
-    }
+    argmax_val[tid]
+        = ::__half2float(px[i * skip]) == max_val
+        ? min(i, argmax_val[tid])
+        : argmax_val[tid];
   }
   ::__syncthreads();
 #define REDUCE(k) \

--- a/primitiv/device_ops/cuda16/min.cu
+++ b/primitiv/device_ops/cuda16/min.cu
@@ -86,9 +86,7 @@ __global__ void min_bw_dev(
   REDUCE(2)
   REDUCE(1)
 #undef REDUCE
-  const float pgxf = ::__half2float(pgx[argmin_val[0] * skip]);
-  const float pgyf = ::__half2float(pgy[bid]);
-  if (tid == 0) pgx[argmin_val[0] * skip] = ::__float2half(pgxf + pgyf);
+  if (tid == 0) INPLACE_ADD(pgx + argmin_val[0] * skip, ::__half2float(pgy[bid]));
 }
 
 }  // namespace

--- a/primitiv/device_ops/cuda16/min.cu
+++ b/primitiv/device_ops/cuda16/min.cu
@@ -1,0 +1,158 @@
+#include <primitiv/config.h>
+
+#include <primitiv/cuda16_device.h>
+#include <primitiv/internal/cuda_utils.h>
+#include <primitiv/device_ops/cuda16/common.h>
+
+namespace {
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void min_fw_dev(
+    const half *px, std::uint32_t skip, std::uint32_t n, half *py) {
+  __shared__ float temp[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  temp[tid] = FLOAT_POSITIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = ::__half2float(px[i * skip]);
+    if (val < temp[tid]) {
+      temp[tid] = val;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (temp[tid + k] < temp[tid]) { \
+        temp[tid] = temp[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  if (tid == 0) py[bid] = ::__float2half(temp[0]);
+}
+
+template<std::uint32_t BLOCK_SIZE>
+__global__ void min_bw_dev(
+    const half *px, const half *py, const half *pgy,
+    std::uint32_t skip, std::uint32_t n, half *pgx) {
+  __shared__ float min_val[BLOCK_SIZE];
+  __shared__ std::uint32_t argmin_val[BLOCK_SIZE];
+  const std::uint32_t bid = blockIdx.x;
+  const std::uint32_t tid = threadIdx.x;
+  px += bid % skip + (bid / skip) * skip * n;
+  pgx += bid % skip + (bid / skip) * skip * n;
+  min_val[tid] = FLOAT_POSITIVE_INFINITY;
+  for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
+    const float val = ::__half2float(px[i * skip]);
+    if (val < min_val[tid]) {
+      min_val[tid] = val;
+      argmin_val[tid] = i;
+    }
+  }
+  ::__syncthreads();
+#define REDUCE(k) \
+  if (BLOCK_SIZE >= k << 1) { \
+    if (tid < k) { \
+      if (min_val[tid + k] < min_val[tid] \
+          || (min_val[tid + k] == min_val[tid] \
+              && argmin_val[tid + k] < argmin_val[tid])) { \
+        min_val[tid] = min_val[tid + k]; \
+        argmin_val[tid] = argmin_val[tid + k]; \
+      } \
+    } \
+    ::__syncthreads(); \
+  }
+  REDUCE(512)
+  REDUCE(256)
+  REDUCE(128)
+  REDUCE(64)
+  REDUCE(32)
+  REDUCE(16)
+  REDUCE(8)
+  REDUCE(4)
+  REDUCE(2)
+  REDUCE(1)
+#undef REDUCE
+  const float pgxf = ::__half2float(pgx[argmin_val[0] * skip]);
+  const float pgyf = ::__half2float(pgy[bid]);
+  if (tid == 0) pgx[argmin_val[0] * skip] = ::__float2half(pgxf + pgyf);
+}
+
+}  // namespace
+
+namespace primitiv {
+namespace devices {
+
+void CUDA16::min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: \
+      ::min_fw_dev<k><<<r, k>>>(CDATA(half, x), s, n, MDATA(half, y)); \
+      break;
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+void CUDA16::min_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t block_size = dim1_x_;
+  while (block_size >> 1 >= n) block_size >>= 1;
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  switch (block_size) {
+#define CASE(k) \
+    case k: \
+      ::min_bw_dev<k><<<r, k>>>( \
+          CDATA(half, x), CDATA(half, y), CDATA(half, gy), \
+          s, n, MDATA(half, gx)); \
+      break;
+    CASE(1024);
+    CASE(512);
+    CASE(256);
+    CASE(128);
+    CASE(64);
+    CASE(32);
+    CASE(16);
+    CASE(8);
+    CASE(4);
+    CASE(2);
+    CASE(1);
+#undef CASE
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/cuda16/min.cu
+++ b/primitiv/device_ops/cuda16/min.cu
@@ -49,10 +49,10 @@ __global__ void min_bw_dev(
   pgx += bid % skip + (bid / skip) * skip * n;
   argmin_val[tid] = n;
   for (std::uint32_t i = tid; i < n; i += BLOCK_SIZE) {
-    if (::__half2float(px[i * skip]) == min_val) {
-      argmin_val[tid] = i;
-      break;
-    }
+    argmin_val[tid]
+        = ::__half2float(px[i * skip]) == min_val
+        ? min(i, argmin_val[tid])
+        : argmin_val[tid];
   }
   ::__syncthreads();
 #define REDUCE(k) \

--- a/primitiv/device_ops/eigen/max.cc
+++ b/primitiv/device_ops/eigen/max.cc
@@ -1,0 +1,56 @@
+#include <primitiv/config.h>
+
+#include <primitiv/eigen_device.h>
+#include <primitiv/device_ops/eigen/common.h>
+
+namespace primitiv {
+namespace devices {
+
+void Eigen::max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  // TODO(vbkaisetsu): Optimize this functions using Eigen operations.
+
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *px = CDATA(x);
+  float *py = MDATA(y);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    float tmp = px[offset];
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] > tmp) {
+        tmp = px[offset];
+      }
+      offset += skip1;
+    }
+    py[i] = tmp;
+  }
+}
+
+void Eigen::max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) {
+  // TODO(vbkaisetsu): Optimize this functions using Eigen operations.
+
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *py = CDATA(y);
+  const float *px = CDATA(x);
+  const float *pgy = CDATA(gy);
+  float *pgx = MDATA(gx);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    const float maxval = py[i];
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] == maxval) {
+        pgx[offset] += pgy[i];
+        break;
+      }
+      offset += skip1;
+    }
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/eigen/min.cc
+++ b/primitiv/device_ops/eigen/min.cc
@@ -1,0 +1,56 @@
+#include <primitiv/config.h>
+
+#include <primitiv/eigen_device.h>
+#include <primitiv/device_ops/eigen/common.h>
+
+namespace primitiv {
+namespace devices {
+
+void Eigen::min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  // TODO(vbkaisetsu): Optimize this functions using Eigen operations.
+
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *px = CDATA(x);
+  float *py = MDATA(y);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    float tmp = px[offset];
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] < tmp) {
+        tmp = px[offset];
+      }
+      offset += skip1;
+    }
+    py[i] = tmp;
+  }
+}
+
+void Eigen::min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) {
+  // TODO(vbkaisetsu): Optimize this functions using Eigen operations.
+
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *py = CDATA(y);
+  const float *px = CDATA(x);
+  const float *pgy = CDATA(gy);
+  float *pgx = MDATA(gx);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    const float minval = py[i];
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] == minval) {
+        pgx[offset] += pgy[i];
+        break;
+      }
+      offset += skip1;
+    }
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/naive/max.cc
+++ b/primitiv/device_ops/naive/max.cc
@@ -1,0 +1,52 @@
+#include <primitiv/config.h>
+
+#include <primitiv/naive_device.h>
+#include <primitiv/device_ops/naive/common.h>
+
+namespace primitiv {
+namespace devices {
+
+void Naive::max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *px = CDATA(x);
+  float *py = MDATA(y);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    float tmp = px[offset];
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] > tmp) {
+        tmp = px[offset];
+      }
+      offset += skip1;
+    }
+    py[i] = tmp;
+  }
+}
+
+void Naive::max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *py = CDATA(y);
+  const float *px = CDATA(x);
+  const float *pgy = CDATA(gy);
+  float *pgx = MDATA(gx);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    const float maxval = py[i];
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] == maxval) {
+        pgx[offset] += pgy[i];
+        break;
+      }
+      offset += skip1;
+    }
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/device_ops/naive/min.cc
+++ b/primitiv/device_ops/naive/min.cc
@@ -1,0 +1,52 @@
+#include <primitiv/config.h>
+
+#include <primitiv/naive_device.h>
+#include <primitiv/device_ops/naive/common.h>
+
+namespace primitiv {
+namespace devices {
+
+void Naive::min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *px = CDATA(x);
+  float *py = MDATA(y);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    float tmp = px[offset];
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] < tmp) {
+        tmp = px[offset];
+      }
+      offset += skip1;
+    }
+    py[i] = tmp;
+  }
+}
+
+void Naive::min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
+  const float *py = CDATA(y);
+  const float *px = CDATA(x);
+  const float *pgy = CDATA(gy);
+  float *pgx = MDATA(gx);
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    const float minval = py[i];
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
+    for (std::uint32_t j = 0; j < n; ++j) {
+      if (px[offset] == minval) {
+        pgx[offset] += pgy[i];
+        break;
+      }
+      offset += skip1;
+    }
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/eigen_device.h
+++ b/primitiv/eigen_device.h
@@ -138,6 +138,11 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
+  void max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+  void min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+
   void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;

--- a/primitiv/naive_device.h
+++ b/primitiv/naive_device.h
@@ -138,6 +138,11 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
+  void max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+  void min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+
   void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;

--- a/primitiv/node_funcs.cc
+++ b/primitiv/node_funcs.cc
@@ -253,6 +253,16 @@ Node elu(const Node &x, float a) {
 }
 
 template<>
+Node max(const Node &x, std::uint32_t dim) {
+  return REGX(x, Max(dim), x)[0];
+}
+
+template<>
+Node min(const Node &x, std::uint32_t dim) {
+  return REGX(x, Min(dim), x)[0];
+}
+
+template<>
 Node sum(const Node &x, std::uint32_t dim) {
   return REGX(x, Sum(dim), x)[0];
 }

--- a/primitiv/opencl_device.cc
+++ b/primitiv/opencl_device.cc
@@ -315,6 +315,15 @@ public:
       CONFIGURE_KERNEL(divide_bw);
       CONFIGURE_KERNEL(pow_bw);
 
+      CONFIGURE_KERNEL_LIST(max_fw);
+      CONFIGURE_KERNEL_LIST(min_fw);
+      CONFIGURE_KERNEL_LIST(max_bw);
+      CONFIGURE_KERNEL_LIST(min_bw);
+      max_fw_group_size = calc_dim1_size(max_fw_group_size);
+      min_fw_group_size = calc_dim1_size(min_fw_group_size);
+      max_bw_group_size = calc_dim1_size(max_bw_group_size);
+      min_bw_group_size = calc_dim1_size(min_bw_group_size);
+
       CONFIGURE_KERNEL_LIST(sum_fw);
       CONFIGURE_KERNEL_LIST(logsumexp_fw);
       sum_fw_group_size = calc_dim1_size(sum_fw_group_size);
@@ -431,6 +440,11 @@ public:
   DECL_KERNEL(multiply_bw);
   DECL_KERNEL(divide_bw);
   DECL_KERNEL(pow_bw);
+
+  DECL_KERNEL_LIST(max_fw, 11);
+  DECL_KERNEL_LIST(min_fw, 11);
+  DECL_KERNEL_LIST(max_bw, 11);
+  DECL_KERNEL_LIST(min_bw, 11);
 
   DECL_KERNEL_LIST(sum_fw, 11);
   DECL_KERNEL_LIST(logsumexp_fw, 11);
@@ -1274,6 +1288,142 @@ void OpenCL::matmul_bw_impl(
       beta,
       MDATA(gb)(), 0, dj,
       &state_->queue(), nullptr);
+  }
+}
+
+void OpenCL::max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t group_size = std::min(state_->max_fw_group_size, 1024u);
+  while (group_size >> 1 >= n) group_size >>= 1;
+  switch (group_size) {
+#define CASE(k, m) \
+    case k: \
+      state_->max_fw_kernel[m].setArg(0, CDATA(x)); \
+      state_->max_fw_kernel[m].setArg(1, s); \
+      state_->max_fw_kernel[m].setArg(2, n); \
+      state_->max_fw_kernel[m].setArg(3, MDATA(y)); \
+      state_->queue.enqueueNDRangeKernel( \
+          state_->max_fw_kernel[m], \
+          cl::NullRange, cl::NDRange(r * k), cl::NDRange(k)); \
+      break;
+    CASE(1024, 10);
+    CASE(512, 9);
+    CASE(256, 8);
+    CASE(128, 7);
+    CASE(64, 6);
+    CASE(32, 5);
+    CASE(16, 4);
+    CASE(8, 3);
+    CASE(4, 2);
+    CASE(2, 1);
+    CASE(1, 0);
+#undef CASE
+  }
+}
+
+void OpenCL::max_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t group_size = std::min(state_->max_bw_group_size, 1024u);
+  while (group_size >> 1 >= n) group_size >>= 1;
+  switch (group_size) {
+#define CASE(k, m) \
+    case k: \
+      state_->max_bw_kernel[m].setArg(0, CDATA(x)); \
+      state_->max_bw_kernel[m].setArg(1, CDATA(y)); \
+      state_->max_bw_kernel[m].setArg(2, CDATA(gy)); \
+      state_->max_bw_kernel[m].setArg(3, s); \
+      state_->max_bw_kernel[m].setArg(4, n); \
+      state_->max_bw_kernel[m].setArg(5, MDATA(gx)); \
+      state_->queue.enqueueNDRangeKernel( \
+          state_->max_bw_kernel[m], \
+          cl::NullRange, cl::NDRange(r * k), cl::NDRange(k)); \
+      break;
+    CASE(1024, 10);
+    CASE(512, 9);
+    CASE(256, 8);
+    CASE(128, 7);
+    CASE(64, 6);
+    CASE(32, 5);
+    CASE(16, 4);
+    CASE(8, 3);
+    CASE(4, 2);
+    CASE(2, 1);
+    CASE(1, 0);
+#undef CASE
+  }
+}
+
+void OpenCL::min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t group_size = std::min(state_->min_fw_group_size, 1024u);
+  while (group_size >> 1 >= n) group_size >>= 1;
+  switch (group_size) {
+#define CASE(k, m) \
+    case k: \
+      state_->min_fw_kernel[m].setArg(0, CDATA(x)); \
+      state_->min_fw_kernel[m].setArg(1, s); \
+      state_->min_fw_kernel[m].setArg(2, n); \
+      state_->min_fw_kernel[m].setArg(3, MDATA(y)); \
+      state_->queue.enqueueNDRangeKernel( \
+          state_->min_fw_kernel[m], \
+          cl::NullRange, cl::NDRange(r * k), cl::NDRange(k)); \
+      break;
+    CASE(1024, 10);
+    CASE(512, 9);
+    CASE(256, 8);
+    CASE(128, 7);
+    CASE(64, 6);
+    CASE(32, 5);
+    CASE(16, 4);
+    CASE(8, 3);
+    CASE(4, 2);
+    CASE(2, 1);
+    CASE(1, 0);
+#undef CASE
+  }
+}
+
+void OpenCL::min_bw_impl(
+    const Tensor &x, const Tensor &y, const Tensor &gy,
+    std::uint32_t dim, Tensor &gx) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t r = y.shape().size();
+  const std::uint32_t s = y.shape().lower_volume(dim);
+  std::uint32_t group_size = std::min(state_->min_bw_group_size, 1024u);
+  while (group_size >> 1 >= n) group_size >>= 1;
+  switch (group_size) {
+#define CASE(k, m) \
+    case k: \
+      state_->min_bw_kernel[m].setArg(0, CDATA(x)); \
+      state_->min_bw_kernel[m].setArg(1, CDATA(y)); \
+      state_->min_bw_kernel[m].setArg(2, CDATA(gy)); \
+      state_->min_bw_kernel[m].setArg(3, s); \
+      state_->min_bw_kernel[m].setArg(4, n); \
+      state_->min_bw_kernel[m].setArg(5, MDATA(gx)); \
+      state_->queue.enqueueNDRangeKernel( \
+          state_->min_bw_kernel[m], \
+          cl::NullRange, cl::NDRange(r * k), cl::NDRange(k)); \
+      break;
+    CASE(1024, 10);
+    CASE(512, 9);
+    CASE(256, 8);
+    CASE(128, 7);
+    CASE(64, 6);
+    CASE(32, 5);
+    CASE(16, 4);
+    CASE(8, 3);
+    CASE(4, 2);
+    CASE(2, 1);
+    CASE(1, 0);
+#undef CASE
   }
 }
 

--- a/primitiv/opencl_device.h
+++ b/primitiv/opencl_device.h
@@ -182,6 +182,11 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
+  void max_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void min_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void max_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+  void min_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, std::uint32_t dim, Tensor &gx) override;
+
   void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
   void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;

--- a/primitiv/opencl_device_kernel.cl
+++ b/primitiv/opencl_device_kernel.cl
@@ -25,7 +25,7 @@ kernel void argmax_kernel_##GROUP_SIZE( \
   local float max_val[GROUP_SIZE]; \
   local unsigned argmax_val[GROUP_SIZE]; \
   px += bid % skip + (bid / skip) * skip * n; \
-  max_val[tid] = -1e38; \
+  max_val[tid] = -INFINITY; \
   for (unsigned i = tid; i < n; i += GROUP_SIZE) { \
     const float val = px[i * skip]; \
     if (val > max_val[tid]) { \
@@ -83,7 +83,7 @@ kernel void argmin_kernel_##GROUP_SIZE( \
   local float min_val[GROUP_SIZE]; \
   local unsigned argmin_val[GROUP_SIZE]; \
   px += bid % skip + (bid / skip) * skip * n; \
-  min_val[tid] = 1e38; \
+  min_val[tid] = INFINITY; \
   for (unsigned i = tid; i < n; i += GROUP_SIZE) { \
     const float val = px[i * skip]; \
     if (val < min_val[tid]) { \

--- a/primitiv/opencl_device_kernel.cl
+++ b/primitiv/opencl_device_kernel.cl
@@ -6,7 +6,9 @@ inline float inline_div(const float a, const float b) { return a / b; }
 #define REDUCE(k, GROUP_SIZE) \
   if (GROUP_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (max_val[tid + k] > max_val[tid]) { \
+      if (max_val[tid + k] > max_val[tid] \
+          || (max_val[tid + k] == max_val[tid] \
+              && argmax_val[tid + k] < argmax_val[tid])) { \
         max_val[tid] = max_val[tid + k]; \
         argmax_val[tid] = argmax_val[tid + k]; \
       } \
@@ -62,7 +64,9 @@ ARGMAX_KERNEL(1)
 #define REDUCE(k, GROUP_SIZE) \
   if (GROUP_SIZE >= k << 1) { \
     if (tid < k) { \
-      if (min_val[tid + k] < min_val[tid]) { \
+      if (min_val[tid + k] < min_val[tid] \
+          || (min_val[tid + k] == min_val[tid] \
+              && argmin_val[tid + k] < argmin_val[tid])) { \
         min_val[tid] = min_val[tid + k]; \
         argmin_val[tid] = argmin_val[tid + k]; \
       } \

--- a/primitiv/opencl_device_kernel.cl
+++ b/primitiv/opencl_device_kernel.cl
@@ -509,10 +509,10 @@ kernel void max_bw_kernel_##GROUP_SIZE( \
   pgx += bid % skip + (bid / skip) * skip * n; \
   argmax_val[tid] = n; \
   for (unsigned i = tid; i < n; i += GROUP_SIZE) { \
-    if (px[i * skip] == py[bid]) { \
-      argmax_val[tid] = i; \
-      break; \
-    } \
+    argmax_val[tid] \
+        = px[i * skip] == max_val \
+        ? min(i, argmax_val[tid]) \
+        : argmax_val[tid]; \
   } \
   barrier(CLK_LOCAL_MEM_FENCE); \
   REDUCE(512, GROUP_SIZE) \
@@ -607,10 +607,10 @@ kernel void min_bw_kernel_##GROUP_SIZE( \
   pgx += bid % skip + (bid / skip) * skip * n; \
   argmin_val[tid] = n; \
   for (unsigned i = tid; i < n; i += GROUP_SIZE) { \
-    if (px[i * skip] == py[bid]) { \
-      argmin_val[tid] = i; \
-      break; \
-    } \
+    argmin_val[tid] \
+        = px[i * skip] == min_val \
+        ? min(i, argmin_val[tid]) \
+        : argmin_val[tid]; \
   } \
   barrier(CLK_LOCAL_MEM_FENCE); \
   REDUCE(512, GROUP_SIZE) \

--- a/primitiv/operator_impl.h
+++ b/primitiv/operator_impl.h
@@ -183,6 +183,22 @@ private:
   Shape shape_;
 };
 
+class Max : public Operator {
+  PRIMITIV_DECL_DEFAULTS_AND_FORWARD(1, 1);
+public:
+  explicit Max(std::uint32_t dim) : dim_(dim) {}
+private:
+  std::uint32_t dim_;
+};
+
+class Min : public Operator {
+  PRIMITIV_DECL_DEFAULTS_AND_FORWARD(1, 1);
+public:
+  explicit Min(std::uint32_t dim) : dim_(dim) {}
+private:
+  std::uint32_t dim_;
+};
+
 class Sum : public Operator {
   PRIMITIV_DECL_DEFAULTS_AND_FORWARD(1, 1);
 public:

--- a/primitiv/tensor_funcs.cc
+++ b/primitiv/tensor_funcs.cc
@@ -268,6 +268,16 @@ Tensor elu(const Tensor &x, float a) {
 }
 
 template<>
+Tensor max(const Tensor &x, std::uint32_t dim) {
+  return x.device().max_fw(x, dim);
+}
+
+template<>
+Tensor min(const Tensor &x, std::uint32_t dim) {
+  return x.device().min_fw(x, dim);
+}
+
+template<>
 Tensor sum(const Tensor &x, std::uint32_t dim) {
   return x.device().sum_fw(x, dim);
 }

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -1,5 +1,6 @@
 #include <primitiv/config.h>
 
+#include <algorithm>
 #include <cmath>
 #include <vector>
 #include <gtest/gtest.h>
@@ -749,6 +750,212 @@ TEST_F(TensorBackwardTest, CheckELU) {
         = dev_type == Device::DeviceType::CUDA16 ? 75000
         : 12;
       EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
+    }
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckMaxDims) {
+  const vector<float> x_data = {
+    0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8,
+  };
+  const vector<vector<float>> y_data = {
+    {2, 8, 5, -3, 0, -6},
+    {6, 7, 8, 0, -1, -2},
+    {0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8},
+  };
+  const vector<vector<float>> gy_data = {
+    {1, 2, 6, 5, 3, 4},
+    {-1, 1, -2, 2, -3, 3},
+    {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
+  };
+  const vector<vector<float>> expected = {
+    {0, 0, 1, 0, 0, 2, 0, 0, 6, 5, 0, 0, 3, 0, 0, -6, 0, 0},
+    {0, 0, 0, -1, 1, -2, 0, 0, 0, 0, 0, 0, 2, -3, 3, 0, 0, 0},
+    {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
+  };
+
+  for (Device *dev : devices) {
+    for (const std::uint32_t i : {0u, 1u, 2u}) {
+      try {
+        const Shape r({3, 3}, 2);
+        const Shape s = r.resize_dim(i, 1);
+        const Tensor x = dev->new_tensor_by_vector(r, x_data);
+        const Tensor y = dev->new_tensor_by_vector(s, y_data[i]);
+        const Tensor gy = dev->new_tensor_by_vector(s, gy_data[i]);
+        Tensor gx = dev->new_tensor_by_constant(r, 0);
+        dev->max_bw(x, y, gy, i, gx);
+        EXPECT_TRUE(vector_match(expected[i], gx.to_vector()));
+      } IGNORE_NOT_IMPLEMENTED
+    }
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckMaxLarge) {
+  std::mt19937 rng;
+  const vector<std::uint32_t> ns {
+    1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024,
+    1025, 2047, 2048, 2049, 65535, 65536, 65537,
+  };
+
+  for (Device *dev : devices) {
+    for (const std::uint32_t n : ns) {
+      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+        // NOTE(vbkaisetsu):
+        // Half-precision types have only (10+1) bits resolution.
+        continue;
+      }
+
+      vector<float> x_data(n);
+      vector<float> y_data = {static_cast<float>(n - 1)};
+      vector<float> gy_data = {1};
+      std::iota(begin(x_data), end(x_data), 0);
+      std::shuffle(begin(x_data), end(x_data), rng);
+      const auto it = std::find(begin(x_data), end(x_data), n - 1);
+      const std::uint32_t pos = std::distance(begin(x_data), it);
+      const Tensor x = dev->new_tensor_by_vector({n}, x_data);
+      const Tensor y = dev->new_tensor_by_vector({1}, y_data);
+      const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
+      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      dev->max_bw(x, y, gy, 0, gx);
+      EXPECT_EQ(1, gx.to_vector()[pos]);
+    }
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckMaxMultipleLarge) {
+  std::mt19937 rng;
+  const vector<std::uint32_t> ns {
+    1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024,
+    1025, 2047, 2048, 2049, 65535, 65536, 65537,
+  };
+
+  for (Device *dev : devices) {
+    for (const std::uint32_t n : ns) {
+      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+        // NOTE(vbkaisetsu):
+        // Half-precision types have only (10+1) bits resolution.
+        continue;
+      }
+
+      vector<float> x_data(n);
+      vector<float> y_data = {static_cast<float>(n - 1)};
+      vector<float> gy_data = {1};
+      std::iota(begin(x_data), end(x_data), 0);
+      for (std::uint32_t i = 0; i < 16 && i < n; ++i) {
+        x_data[i] = n - 1;
+      }
+      std::shuffle(begin(x_data), end(x_data), rng);
+      const auto it = std::find(begin(x_data), end(x_data), n - 1);
+      const std::uint32_t pos = std::distance(begin(x_data), it);
+      const Tensor x = dev->new_tensor_by_vector({n}, x_data);
+      const Tensor y = dev->new_tensor_by_vector({1}, y_data);
+      const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
+      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      dev->max_bw(x, y, gy, 0, gx);
+      EXPECT_EQ(1, gx.to_vector()[pos]);
+    }
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckMinDims) {
+  const vector<float> x_data = {
+    3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5,
+  };
+  const vector<vector<float>> y_data = {
+    {3, 0, 6, -2, -8, -5},
+    {0, 1, 2, -6, -7, -8},
+    {3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5},
+  };
+  const vector<vector<float>> gy_data = {
+    {1, 2, 6, 5, 3, 4},
+    {-1, 1, -2, 2, -3, 3},
+    {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
+  };
+  const vector<vector<float>> expected = {
+    {1, 0, 0, 2, 0, 0, 6, 0, 0, 0, 0, 5, 0, 0, 3, 0, 0, 4},
+    {0, 0, 0, -1, 1, -2, 0, 0, 0, 0, 0, 0, 2, -3, -8, 0, 0, 0},
+    {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
+  };
+
+  for (Device *dev : devices) {
+    for (const std::uint32_t i : {0u, 1u, 2u}) {
+      try {
+        const Shape r({3, 3}, 2);
+        const Shape s = r.resize_dim(i, 1);
+        const Tensor x = dev->new_tensor_by_vector(r, x_data);
+        const Tensor y = dev->new_tensor_by_vector(s, y_data[i]);
+        const Tensor gy = dev->new_tensor_by_vector(s, gy_data[i]);
+        Tensor gx = dev->new_tensor_by_constant(r, 0);
+        dev->min_bw(x, y, gy, i, gx);
+        EXPECT_TRUE(vector_match(expected[i], gx.to_vector()));
+      } IGNORE_NOT_IMPLEMENTED
+    }
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckMinLarge) {
+  std::mt19937 rng;
+  const vector<std::uint32_t> ns {
+    1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024,
+    1025, 2047, 2048, 2049, 65535, 65536, 65537,
+  };
+
+  for (Device *dev : devices) {
+    for (const std::uint32_t n : ns) {
+      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+        // NOTE(vbkaisetsu):
+        // Half-precision types have only (10+1) bits resolution.
+        continue;
+      }
+
+      vector<float> x_data(n);
+      vector<float> y_data = {0};
+      vector<float> gy_data = {1};
+      std::iota(begin(x_data), end(x_data), 0);
+      std::shuffle(begin(x_data), end(x_data), rng);
+      const auto it = std::find(begin(x_data), end(x_data), 0);
+      const std::uint32_t pos = std::distance(begin(x_data), it);
+      const Tensor x = dev->new_tensor_by_vector({n}, x_data);
+      const Tensor y = dev->new_tensor_by_vector({1}, y_data);
+      const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
+      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      dev->min_bw(x, y, gy, 0, gx);
+      EXPECT_EQ(1, gx.to_vector()[pos]);
+    }
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckMinMultipleLarge) {
+  std::mt19937 rng;
+  const vector<std::uint32_t> ns {
+    1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024,
+    1025, 2047, 2048, 2049, 65535, 65536, 65537,
+  };
+
+  for (Device *dev : devices) {
+    for (const std::uint32_t n : ns) {
+      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+        // NOTE(vbkaisetsu):
+        // Half-precision types have only (10+1) bits resolution.
+        continue;
+      }
+
+      vector<float> x_data(n);
+      vector<float> y_data = {0};
+      vector<float> gy_data = {1};
+      std::iota(begin(x_data), end(x_data), 0);
+      for (std::uint32_t i = 0; i < 16 && i < n; ++i) {
+        x_data[i] = 0;
+      }
+      std::shuffle(begin(x_data), end(x_data), rng);
+      const auto it = std::find(begin(x_data), end(x_data), 0);
+      const std::uint32_t pos = std::distance(begin(x_data), it);
+      const Tensor x = dev->new_tensor_by_vector({n}, x_data);
+      const Tensor y = dev->new_tensor_by_vector({1}, y_data);
+      const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
+      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      dev->min_bw(x, y, gy, 0, gx);
+      EXPECT_EQ(1, gx.to_vector()[pos]);
     }
   }
 }

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -843,7 +843,9 @@ TEST_F(TensorBackwardTest, CheckMaxMultipleLarge) {
       vector<float> y_data = {static_cast<float>(n - 1)};
       vector<float> gy_data = {1};
       std::iota(begin(x_data), end(x_data), 0);
-      for (std::uint32_t i = 0; i < 16 && i < n; ++i) {
+      // NOTE(vbkaisetsu):
+      // Generates a tensor that has some duplicated maximum values.
+      for (std::uint32_t i = 0; i < 10 && i < n; ++i) {
         x_data[i] = n - 1;
       }
       std::shuffle(begin(x_data), end(x_data), rng);
@@ -950,7 +952,9 @@ TEST_F(TensorBackwardTest, CheckMinMultipleLarge) {
       vector<float> y_data = {0};
       vector<float> gy_data = {1};
       std::iota(begin(x_data), end(x_data), 0);
-      for (std::uint32_t i = 0; i < 16 && i < n; ++i) {
+      // NOTE(vbkaisetsu):
+      // Generates a tensor that has some duplicated minimum values.
+      for (std::uint32_t i = 0; i < 10 && i < n; ++i) {
         x_data[i] = 0;
       }
       std::shuffle(begin(x_data), end(x_data), rng);

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -769,9 +769,9 @@ TEST_F(TensorBackwardTest, CheckMaxDims) {
     {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
   };
   const vector<vector<float>> expected = {
-    {0, 0, 1, 0, 0, 2, 0, 0, 6, 5, 0, 0, 3, 0, 0, -6, 0, 0},
-    {0, 0, 0, -1, 1, -2, 0, 0, 0, 0, 0, 0, 2, -3, 3, 0, 0, 0},
-    {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
+    {1, 1, 2, 1, 1, 3, 1, 1, 7, 6, 1, 1, 4, 1, 1, -5, 1, 1},
+    {1, 1, 1, 0, 2, -1, 1, 1, 1, 1, 1, 1, 3, -2, 4, 1, 1, 1},
+    {1, 2, 1, 0, 1, 2, 1, 0, 3, 2, 1, 0, 1, 2, 3, 4, 5, 7},
   };
 
   for (Device *dev : devices) {
@@ -782,7 +782,7 @@ TEST_F(TensorBackwardTest, CheckMaxDims) {
         const Tensor x = dev->new_tensor_by_vector(r, x_data);
         const Tensor y = dev->new_tensor_by_vector(s, y_data[i]);
         const Tensor gy = dev->new_tensor_by_vector(s, gy_data[i]);
-        Tensor gx = dev->new_tensor_by_constant(r, 0);
+        Tensor gx = dev->new_tensor_by_constant(r, 1);
         dev->max_bw(x, y, gy, i, gx);
         EXPECT_TRUE(vector_match(expected[i], gx.to_vector()));
       } IGNORE_NOT_IMPLEMENTED
@@ -812,12 +812,14 @@ TEST_F(TensorBackwardTest, CheckMaxLarge) {
       std::shuffle(begin(x_data), end(x_data), rng);
       const auto it = std::find(begin(x_data), end(x_data), n - 1);
       const std::uint32_t pos = std::distance(begin(x_data), it);
+      vector<float> expected(n, 1);
+      expected[pos] = 2;
       const Tensor x = dev->new_tensor_by_vector({n}, x_data);
       const Tensor y = dev->new_tensor_by_vector({1}, y_data);
       const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
-      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      Tensor gx = dev->new_tensor_by_constant({n}, 1);
       dev->max_bw(x, y, gy, 0, gx);
-      EXPECT_EQ(1, gx.to_vector()[pos]);
+      EXPECT_TRUE(vector_match(expected, gx.to_vector()));
     }
   }
 }
@@ -847,12 +849,14 @@ TEST_F(TensorBackwardTest, CheckMaxMultipleLarge) {
       std::shuffle(begin(x_data), end(x_data), rng);
       const auto it = std::find(begin(x_data), end(x_data), n - 1);
       const std::uint32_t pos = std::distance(begin(x_data), it);
+      vector<float> expected(n, 1);
+      expected[pos] = 2;
       const Tensor x = dev->new_tensor_by_vector({n}, x_data);
       const Tensor y = dev->new_tensor_by_vector({1}, y_data);
       const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
-      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      Tensor gx = dev->new_tensor_by_constant({n}, 1);
       dev->max_bw(x, y, gy, 0, gx);
-      EXPECT_EQ(1, gx.to_vector()[pos]);
+      EXPECT_TRUE(vector_match(expected, gx.to_vector()));
     }
   }
 }
@@ -872,9 +876,9 @@ TEST_F(TensorBackwardTest, CheckMinDims) {
     {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
   };
   const vector<vector<float>> expected = {
-    {1, 0, 0, 2, 0, 0, 6, 0, 0, 0, 0, 5, 0, 0, 3, 0, 0, 4},
-    {0, 0, 0, -1, 1, -2, 0, 0, 0, 0, 0, 0, 2, -3, -8, 0, 0, 0},
-    {0, 1, 0, -1, 0, 1, 0, -1, 2, 1, 0, -1, 0, 1, 2, 3, 4, 6},
+    {2, 1, 1, 3, 1, 1, 7, 1, 1, 1, 1, 6, 1, 1, 4, 1, 1, 5},
+    {1, 1, 1, 0, 2, -1, 1, 1, 1, 1, 1, 1, 3, -2, -7, 1, 1, 1},
+    {1, 2, 1, 0, 1, 2, 1, 0, 3, 2, 1, 0, 1, 2, 3, 4, 5, 7},
   };
 
   for (Device *dev : devices) {
@@ -885,7 +889,7 @@ TEST_F(TensorBackwardTest, CheckMinDims) {
         const Tensor x = dev->new_tensor_by_vector(r, x_data);
         const Tensor y = dev->new_tensor_by_vector(s, y_data[i]);
         const Tensor gy = dev->new_tensor_by_vector(s, gy_data[i]);
-        Tensor gx = dev->new_tensor_by_constant(r, 0);
+        Tensor gx = dev->new_tensor_by_constant(r, 1);
         dev->min_bw(x, y, gy, i, gx);
         EXPECT_TRUE(vector_match(expected[i], gx.to_vector()));
       } IGNORE_NOT_IMPLEMENTED
@@ -915,12 +919,14 @@ TEST_F(TensorBackwardTest, CheckMinLarge) {
       std::shuffle(begin(x_data), end(x_data), rng);
       const auto it = std::find(begin(x_data), end(x_data), 0);
       const std::uint32_t pos = std::distance(begin(x_data), it);
+      vector<float> expected(n, 1);
+      expected[pos] = 2;
       const Tensor x = dev->new_tensor_by_vector({n}, x_data);
       const Tensor y = dev->new_tensor_by_vector({1}, y_data);
       const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
-      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      Tensor gx = dev->new_tensor_by_constant({n}, 1);
       dev->min_bw(x, y, gy, 0, gx);
-      EXPECT_EQ(1, gx.to_vector()[pos]);
+      EXPECT_TRUE(vector_match(expected, gx.to_vector()));
     }
   }
 }
@@ -950,12 +956,14 @@ TEST_F(TensorBackwardTest, CheckMinMultipleLarge) {
       std::shuffle(begin(x_data), end(x_data), rng);
       const auto it = std::find(begin(x_data), end(x_data), 0);
       const std::uint32_t pos = std::distance(begin(x_data), it);
+      vector<float> expected(n, 1);
+      expected[pos] = 2;
       const Tensor x = dev->new_tensor_by_vector({n}, x_data);
       const Tensor y = dev->new_tensor_by_vector({1}, y_data);
       const Tensor gy = dev->new_tensor_by_vector({1}, gy_data);
-      Tensor gx = dev->new_tensor_by_constant({n}, 0);
+      Tensor gx = dev->new_tensor_by_constant({n}, 1);
       dev->min_bw(x, y, gy, 0, gx);
-      EXPECT_EQ(1, gx.to_vector()[pos]);
+      EXPECT_TRUE(vector_match(expected, gx.to_vector()));
     }
   }
 }

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -2077,19 +2077,26 @@ TEST_F(TensorForwardTest, CheckELU) {
 }
 
 TEST_F(TensorForwardTest, CheckMaxDims) {
+  struct TestCase {
+    std::uint32_t dim;
+    const Shape shape;
+    const vector<float> expected;
+  };
+  const vector<TestCase> test_cases {
+    {0, Shape({1, 3}, 2), {2, 8, 5, -3, 0, -6}},
+    {1, Shape({3, 1}, 2), {6, 7, 8, 0, -1, -2}},
+    {2, Shape({3, 3}, 2), {0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8}},
+  };
   const vector<float> data = {
     0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8,
-  };
-  const vector<vector<float>> expected = {
-    {2, 8, 5, -3, 0, -6},
-    {6, 7, 8, 0, -1, -2},
-    {0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8},
   };
 
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({3, 3}, 2), data);
-    for (const std::uint32_t i : {0u, 1u, 2u}) {
-      EXPECT_TRUE(vector_match(expected[i], max(a, i).to_vector()));
+    for (const TestCase &tc : test_cases) {
+      const Tensor result = max(a, tc.dim);
+      EXPECT_TRUE(vector_match(tc.expected, result.to_vector()));
+      EXPECT_EQ(tc.shape, result.shape());
     }
   }
 }
@@ -2112,25 +2119,35 @@ TEST_F(TensorForwardTest, CheckMaxLarge) {
       std::iota(begin(data), end(data), 0);
       std::shuffle(begin(data), end(data), rng);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
-      EXPECT_EQ(n - 1, max(a, 0).to_vector()[0]);
+      const Tensor result = max(a, 0);
+      const vector<float> expected {static_cast<float>(n - 1)};
+      EXPECT_TRUE(vector_match(expected, result.to_vector()));
+      EXPECT_EQ(Shape({}), result.shape());
     }
   }
 }
 
 TEST_F(TensorForwardTest, CheckMinDims) {
+  struct TestCase {
+    std::uint32_t dim;
+    const Shape shape;
+    const vector<float> expected;
+  };
+  const vector<TestCase> test_cases {
+    {0, Shape({1, 3}, 2), {3, 0, 6, -2, -8, -5}},
+    {1, Shape({3, 1}, 2), {0, 1, 2, -6, -7, -8}},
+    {2, Shape({3, 3}, 2), {3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5}},
+  };
   const vector<float> data = {
     3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5,
-  };
-  const vector<vector<float>> expected = {
-    {3, 0, 6, -2, -8, -5},
-    {0, 1, 2, -6, -7, -8},
-    {3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5},
   };
 
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({3, 3}, 2), data);
-    for (const std::uint32_t i : {0u, 1u, 2u}) {
-      EXPECT_TRUE(vector_match(expected[i], min(a, i).to_vector()));
+    for (const TestCase &tc : test_cases) {
+      const Tensor result = min(a, tc.dim);
+      EXPECT_TRUE(vector_match(tc.expected, result.to_vector()));
+      EXPECT_EQ(tc.shape, result.shape());
     }
   }
 }
@@ -2153,7 +2170,10 @@ TEST_F(TensorForwardTest, CheckMinLarge) {
       std::iota(begin(data), end(data), 0);
       std::shuffle(begin(data), end(data), rng);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
-      EXPECT_EQ(0, min(a, 0).to_vector()[0]);
+      const Tensor result = min(a, 0);
+      const vector<float> expected {0};
+      EXPECT_TRUE(vector_match(expected, result.to_vector()));
+      EXPECT_EQ(Shape({}), result.shape());
     }
   }
 }

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -708,10 +708,11 @@ TEST_F(TensorTest, CheckArgMaxMultipleLarge) {
         // Half-precision types have only (10+1) bits resolution.
         continue;
       }
-
       vector<float> data(n);
       std::iota(begin(data), end(data), 0);
-      for (std::uint32_t i = 0; i < 16 && i < n; ++i) {
+      // NOTE(vbkaisetsu):
+      // Generates a tensor that has some duplicated maximum values.
+      for (std::uint32_t i = 0; i < 10 && i < n; ++i) {
         data[i] = n - 1;
       }
       std::shuffle(begin(data), end(data), rng);
@@ -784,7 +785,9 @@ TEST_F(TensorTest, CheckArgMinMultipleLarge) {
       }
       vector<float> data(n);
       std::iota(begin(data), end(data), 0);
-      for (std::uint32_t i = 0; i < 16 && i < n; ++i) {
+      // NOTE(vbkaisetsu):
+      // Generates a tensor that has some duplicated minimum values.
+      for (std::uint32_t i = 0; i < 10 && i < n; ++i) {
         data[i] = 0;
       }
       std::shuffle(begin(data), end(data), rng);

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -688,7 +688,8 @@ TEST_F(TensorTest, CheckArgMaxLarge) {
       const auto it = std::find(begin(data), end(data), n - 1);
       const std::uint32_t pos = std::distance(begin(data), it);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
-      EXPECT_EQ(pos, a.argmax(0)[0]);
+      const vector<std::uint32_t> expected {pos};
+      EXPECT_TRUE(vector_match(expected, a.argmax(0)));
     }
   }
 }
@@ -717,7 +718,8 @@ TEST_F(TensorTest, CheckArgMaxMultipleLarge) {
       const auto it = std::find(begin(data), end(data), n - 1);
       const std::uint32_t pos = std::distance(begin(data), it);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
-      EXPECT_EQ(pos, a.argmax(0)[0]);
+      const vector<std::uint32_t> expected {pos};
+      EXPECT_TRUE(vector_match(expected, a.argmax(0)));
     }
   }
 }
@@ -760,7 +762,8 @@ TEST_F(TensorTest, CheckArgMinLarge) {
       const auto it = std::find(begin(data), end(data), 0);
       const std::uint32_t pos = std::distance(begin(data), it);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
-      EXPECT_EQ(pos, a.argmin(0)[0]);
+      const vector<std::uint32_t> expected {pos};
+      EXPECT_TRUE(vector_match(expected, a.argmin(0)));
     }
   }
 }
@@ -788,7 +791,8 @@ TEST_F(TensorTest, CheckArgMinMultipleLarge) {
       const auto it = std::find(begin(data), end(data), 0);
       const std::uint32_t pos = std::distance(begin(data), it);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
-      EXPECT_EQ(pos, a.argmin(0)[0]);
+      const vector<std::uint32_t> expected {pos};
+      EXPECT_TRUE(vector_match(expected, a.argmin(0)));
     }
   }
 }


### PR DESCRIPTION
Related to #181

This branch adds `functions::max()` and `functions::min()` functions.

When multiple elements contain a max value, gradients are back-propagated to lower indexed elements.
e.g.
```
x := [1, 2, 5, 4, 5, 2]
y := max(x, 0)
gy := [1]
The gradient of x becomes:
gx = [0, 0, 1, 0, 0, 0]
```

This branch also fixes `argmax` and `argmin` functions of `CUDA` and `OpenCL` devices that return different results from `Naive` device.