### PR TITLE
Add missing include

### DIFF
--- a/primitiv/msgpack/writer.h
+++ b/primitiv/msgpack/writer.h
@@ -1,6 +1,8 @@
 #ifndef PRIMITIV_MSGPACK_WRITER_H_
 #define PRIMITIV_MSGPACK_WRITER_H_
 
+#include <primitiv/config.h>
+
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -9,7 +11,6 @@
 #include <vector>
 #include <unordered_map>
 
-#include <primitiv/config.h>
 #include <primitiv/error.h>
 #include <primitiv/mixins.h>
 #include <primitiv/msgpack/objects.h>

--- a/primitiv/msgpack/writer.h
+++ b/primitiv/msgpack/writer.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include <unordered_map>
 
+#include <primitiv/config.h>
 #include <primitiv/error.h>
 #include <primitiv/mixins.h>
 #include <primitiv/msgpack/objects.h>


### PR DESCRIPTION
This branch adds missing `#include <primitiv/config.h>`.

`msgpack/writer.h` uses `PRIMITIV_WORDSIZE_64`, but the definition was not included.