### PR TITLE
Fix search problem in doxygen

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -802,7 +802,7 @@ FILE_PATTERNS          = *.h
 # be searched for input files as well.
 # The default value is: NO.
 
-RECURSIVE              = NO
+RECURSIVE              = YES
 
 # The EXCLUDE tag can be used to specify files and/or directories that should be
 # excluded from the INPUT source files. This way you can easily exclude a


### PR DESCRIPTION
C++ headers are not included for the documentation now because the directory structure was changed.
This branch fix the problem of inputting header files.