### PR TITLE
Add permute_dims() function

### DIFF
--- a/primitiv/c/functions.cc
+++ b/primitiv/c/functions.cc
@@ -281,6 +281,28 @@ PRIMITIV_C_STATUS primitivApplyTensorReshape(
 PRIMITIV_C_IMPL_UNARY_FUNC(Flatten, flatten);
 PRIMITIV_C_IMPL_UNARY_FUNC(Transpose, transpose);
 
+PRIMITIV_C_STATUS primitivApplyNodePermuteDims(
+    const primitivNode_t *x, const uint32_t *perm, size_t n,
+    primitivNode_t **y) try {
+  PRIMITIV_C_CHECK_NOT_NULL(x);
+  PRIMITIV_C_CHECK_NOT_NULL(perm);
+  PRIMITIV_C_CHECK_NOT_NULL(y);
+  *y = to_c_ptr_from_value(primitiv::functions::permute_dims(
+     *to_cpp_ptr(x), std::vector<uint32_t>(perm, perm + n)));
+  return PRIMITIV_C_OK;
+} PRIMITIV_C_HANDLE_EXCEPTIONS
+
+PRIMITIV_C_STATUS primitivApplyTensorPermuteDims(
+    const primitivTensor_t *x, const uint32_t *perm, size_t n,
+    primitivTensor_t **y) try {
+  PRIMITIV_C_CHECK_NOT_NULL(x);
+  PRIMITIV_C_CHECK_NOT_NULL(perm);
+  PRIMITIV_C_CHECK_NOT_NULL(y);
+  *y = to_c_ptr_from_value(primitiv::functions::permute_dims(
+      *to_cpp_ptr(x), std::vector<uint32_t>(perm, perm + n)));
+  return PRIMITIV_C_OK;
+} PRIMITIV_C_HANDLE_EXCEPTIONS
+
 PRIMITIV_C_STATUS primitivApplyNodeMatmul(
     const primitivNode_t *a, const primitivNode_t *b, primitivNode_t **y) try {
   PRIMITIV_C_CHECK_NOT_NULL(a);

--- a/primitiv/c/functions.h
+++ b/primitiv/c/functions.h
@@ -100,6 +100,13 @@ PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorReshape(
 PRIMITIV_C_DECL_UNARY_FUNC(Flatten);
 PRIMITIV_C_DECL_UNARY_FUNC(Transpose);
 
+PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyNodePermuteDims(
+    const primitivNode_t *x, const uint32_t *perm, size_t n,
+    primitivNode_t **y);
+PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorPermuteDims(
+    const primitivTensor_t *x, const uint32_t *perm, size_t n,
+    primitivTensor_t **y);
+
 PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyNodeMatmul(
     const primitivNode_t *a, const primitivNode_t *b, primitivNode_t **y);
 PRIMITIV_C_API PRIMITIV_C_STATUS primitivApplyTensorMatmul(

--- a/primitiv/core/basic_functions.h
+++ b/primitiv/core/basic_functions.h
@@ -576,26 +576,33 @@ type_traits::Identity<Var> transpose(const Var &x);
  *        \end{array} \right),
  *        \left( \begin{array}{ccc}
  *          21 & 24 \\ 22 & 25 \\ 23 & 26
- *        \end{array} \right)
- *      \right), \\
- *    \mathrm{permute_dims}(x, [2, 0, 1]) & = &
- *      \left(
- *        \left( \begin{array}{ccc}
- *          1 & 2 & 3 \\ 11 & 12 & 13 \\ 21 & 22 & 23
  *        \end{array} \right),
  *        \left( \begin{array}{ccc}
- *          4 & 5 & 6 \\ 14 & 15 & 16 \\ 24 & 25 & 26
+ *          31 & 34 \\ 32 & 35 \\ 33 & 36
  *        \end{array} \right)
  *      \right), \\
- *    \mathrm{permute_dims}(x, [0, 2, 1]) & = &
+ *    \mathrm{permute\_dims}(x, [1, 2, 0]) & = &
  *      \left(
  *        \left( \begin{array}{ccc}
- *          1 & 11 & 21 \\ 2 & 12 & 22 \\ 3 & 13 & 23
+ *          1 & 11 & 21 & 31 \\ 4 & 14 & 24 & 34
  *        \end{array} \right),
  *        \left( \begin{array}{ccc}
- *          4 & 14 & 24 \\ 5 & 15 & 25 \\ 6 & 16 & 16
+ *          2 & 12 & 22 & 32 \\ 5 & 15 & 25 & 35
+ *        \end{array} \right),
+ *        \left( \begin{array}{ccc}
+ *          3 & 13 & 23 & 33 \\ 6 & 16 & 26 & 36
  *        \end{array} \right)
- *    \right).
+ *      \right), \\
+ *    \mathrm{permute\_dims}(x, [2, 0, 1]) & = &
+ *      \left(
+ *        \left( \begin{array}{ccc}
+ *          1 & 2 & 3 \\ 11 & 12 & 13 \\ 21 & 22 & 23 \\ 31 & 32 & 33
+ *        \end{array} \right),
+ *        \left( \begin{array}{ccc}
+ *          4 & 5 & 6 \\ 14 & 15 & 16 \\ 24 & 35 & 36 \\ 34 & 35 & 36
+ *        \end{array} \right)
+ *      \right), \\
+ *    \mathrm{permute\_dims}(x, [0, 1, 2]) & = & x. \\
  *  \end{array}
  * @f]
  * @param x A variable representing an original data.

--- a/primitiv/core/basic_functions.h
+++ b/primitiv/core/basic_functions.h
@@ -568,28 +568,28 @@ type_traits::Identity<Var> transpose(const Var &x);
  *  \begin{array}{lcl}
  *    x & := &
  *      \left(
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cc}
  *          1 & 4 \\ 2 & 5 \\ 3 & 6
  *        \end{array} \right),
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cc}
  *          11 & 14 \\ 12 & 15 \\ 13 & 16
  *        \end{array} \right),
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cc}
  *          21 & 24 \\ 22 & 25 \\ 23 & 26
  *        \end{array} \right),
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cc}
  *          31 & 34 \\ 32 & 35 \\ 33 & 36
  *        \end{array} \right)
  *      \right), \\
  *    \mathrm{permute\_dims}(x, [1, 2, 0]) & = &
  *      \left(
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cccc}
  *          1 & 11 & 21 & 31 \\ 4 & 14 & 24 & 34
  *        \end{array} \right),
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cccc}
  *          2 & 12 & 22 & 32 \\ 5 & 15 & 25 & 35
  *        \end{array} \right),
- *        \left( \begin{array}{ccc}
+ *        \left( \begin{array}{cccc}
  *          3 & 13 & 23 & 33 \\ 6 & 16 & 26 & 36
  *        \end{array} \right)
  *      \right), \\

--- a/primitiv/core/basic_functions.h
+++ b/primitiv/core/basic_functions.h
@@ -563,6 +563,60 @@ template<typename Var>
 type_traits::Identity<Var> transpose(const Var &x);
 
 /**
+ * Permutes dimensions of a tensor.
+ * @f[
+ *  \begin{array}{lcl}
+ *    x & := &
+ *      \left(
+ *        \left( \begin{array}{ccc}
+ *          1 & 4 \\ 2 & 5 \\ 3 & 6
+ *        \end{array} \right),
+ *        \left( \begin{array}{ccc}
+ *          11 & 14 \\ 12 & 15 \\ 13 & 16
+ *        \end{array} \right),
+ *        \left( \begin{array}{ccc}
+ *          21 & 24 \\ 22 & 25 \\ 23 & 26
+ *        \end{array} \right)
+ *      \right), \\
+ *    \mathrm{permute_dims}(x, [2, 0, 1]) & = &
+ *      \left(
+ *        \left( \begin{array}{ccc}
+ *          1 & 2 & 3 \\ 11 & 12 & 13 \\ 21 & 22 & 23
+ *        \end{array} \right),
+ *        \left( \begin{array}{ccc}
+ *          4 & 5 & 6 \\ 14 & 15 & 16 \\ 24 & 25 & 26
+ *        \end{array} \right)
+ *      \right), \\
+ *    \mathrm{permute_dims}(x, [0, 2, 1]) & = &
+ *      \left(
+ *        \left( \begin{array}{ccc}
+ *          1 & 11 & 21 \\ 2 & 12 & 22 \\ 3 & 13 & 23
+ *        \end{array} \right),
+ *        \left( \begin{array}{ccc}
+ *          4 & 14 & 24 \\ 5 & 15 & 25 \\ 6 & 16 & 16
+ *        \end{array} \right)
+ *    \right).
+ *  \end{array}
+ * @f]
+ * @param x A variable representing an original data.
+ * @param perm A list of dimensions for specifying permutation.
+ * @return A new variable.
+ */
+template<typename Var>
+type_traits::Identity<Var> permute_dims(const Var &x, const std::vector<std::uint32_t> &perm);
+
+/**
+ * Permutes dimensions of a tensor.
+ * @param x A variable representing an original data.
+ * @param perm A list of dimensions for specifying permutation.
+ * @return A new variable.
+ */
+template<typename Var>
+type_traits::Identity<Var> permute_dims(const Var &x, const std::initializer_list<std::uint32_t> perm) {
+  return permute_dims(x, std::vector<std::uint32_t>(perm));
+}
+
+/**
  * Applies a matrix multiplication between two matrices.
  * @param a A variable representing an argument \f$ A \f$. The shape of `a`
  *          must be either a scalar, a column vector or a matrix.

--- a/primitiv/core/device.h
+++ b/primitiv/core/device.h
@@ -131,6 +131,7 @@ public:
   Tensor cos_fw(const Tensor &x);
   Tensor tan_fw(const Tensor &x);
   Tensor transpose_fw(const Tensor &x);
+  Tensor permute_dims_fw(const Tensor &x, const std::vector<std::uint32_t> &perm);
 
   void abs_bw(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx);
   void sqrt_bw(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx);
@@ -143,6 +144,7 @@ public:
   void cos_bw(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx);
   void tan_bw(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx);
   void transpose_bw(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx);
+  void permute_dims_bw(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx);
 
   // Tensor-constant operations.
   Tensor add_const_fw(const Tensor &x, float k);
@@ -396,6 +398,7 @@ private:
   virtual void cos_fw_impl(const Tensor &x, Tensor &y) = 0;
   virtual void tan_fw_impl(const Tensor &x, Tensor &y) = 0;
   virtual void transpose_fw_impl(const Tensor &x, Tensor &y) = 0;
+  virtual void permute_dims_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) = 0;
 
   virtual void abs_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) = 0;
   virtual void sqrt_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) = 0;
@@ -408,6 +411,7 @@ private:
   virtual void cos_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) = 0;
   virtual void tan_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) = 0;
   virtual void transpose_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) = 0;
+  virtual void permute_dims_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx) = 0;
 
   virtual void add_const_fw_impl(const Tensor &x, float k, Tensor &y) = 0;
   virtual void subtract_const_r_fw_impl(const Tensor &x, float k, Tensor &y) = 0;

--- a/primitiv/core/node_funcs.cc
+++ b/primitiv/core/node_funcs.cc
@@ -183,6 +183,11 @@ Node transpose(const Node &x) {
 }
 
 template<>
+Node permute_dims(const Node &x, const std::vector<std::uint32_t> &perm) {
+  return REGX(x, PermuteDims(perm), x)[0];
+}
+
+template<>
 Node matmul(const Node &a, const Node &b) {
   return REGX(a, MatrixMultiply(), a, b)[0];
 }

--- a/primitiv/core/operator_impl.cc
+++ b/primitiv/core/operator_impl.cc
@@ -116,6 +116,7 @@ IMPL_NAME_0(Divide);
 IMPL_NAME_0(Pow);
 
 IMPL_NAME_0(Transpose);
+IMPL_NAME_0(PermuteDims);
 IMPL_NAME_0(MatrixMultiply);
 
 IMPL_NAME_0(Abs);
@@ -253,6 +254,7 @@ FWD_SHAPE_ELEMENTWISE(Multiply);
 FWD_SHAPE_ELEMENTWISE(Divide);
 FWD_SHAPE_ELEMENTWISE(Pow);
 FWD_SHAPE(Transpose) { *y[0] = shape_ops::transpose(*x[0]); }
+FWD_SHAPE(PermuteDims) { *y[0] = shape_ops::permute_dims(*x[0], perm_); }
 FWD_SHAPE(MatrixMultiply) { *y[0] = shape_ops::matmul(*x[0], *x[1]); }
 FWD_SHAPE(Max) { *y[0] = x[0]->resize_dim(dim_, 1); }
 FWD_SHAPE(Min) { *y[0] = x[0]->resize_dim(dim_, 1); }
@@ -412,6 +414,7 @@ FORWARD(Divide) { *y[0] = *x[0] / *x[1]; }
 FORWARD(Pow) { *y[0] = functions::pow(*x[0], *x[1]); }
 
 FORWARD(Transpose) { *y[0] = functions::transpose(*x[0]); }
+FORWARD(PermuteDims) { *y[0] = functions::permute_dims(*x[0], perm_); }
 FORWARD(MatrixMultiply) { *y[0] = functions::matmul(*x[0], *x[1]); }
 
 FORWARD(Sum) { *y[0] = functions::sum(*x[0], dim_); }
@@ -602,6 +605,10 @@ BACKWARD(LReLU) {
 
 BACKWARD(Transpose) {
   gy[0]->device().transpose_bw(*x[0], *y[0], *gy[0], *gx[0]);
+}
+
+BACKWARD(PermuteDims) {
+  gy[0]->device().permute_dims_bw(*x[0], *y[0], *gy[0], perm_, *gx[0]);
 }
 
 BACKWARD(AddConst) {

--- a/primitiv/core/operator_impl.h
+++ b/primitiv/core/operator_impl.h
@@ -302,6 +302,15 @@ PRIMITIV_DECL_BINARY(Divide);
 PRIMITIV_DECL_BINARY(Pow);
 
 PRIMITIV_DECL_UNARY(Transpose);
+
+class PermuteDims : public Operator {
+  PRIMITIV_DECL_DEFAULTS_AND_FORWARD(1, 1);
+public:
+  explicit PermuteDims(const std::vector<std::uint32_t> &perm) : perm_(perm) {}
+private:
+  std::vector<std::uint32_t> perm_;
+};
+
 PRIMITIV_DECL_BINARY(MatrixMultiply);
 
 PRIMITIV_DECL_UNARY(Abs);

--- a/primitiv/core/shape_ops.cc
+++ b/primitiv/core/shape_ops.cc
@@ -4,7 +4,6 @@
 
 #include <primitiv/core/error.h>
 #include <primitiv/core/shape_ops.h>
-#include <primitiv/core/string_utils.h>
 
 namespace primitiv {
 namespace shape_ops {
@@ -126,21 +125,23 @@ Shape transpose(const Shape &x) {
 Shape permute_dims(const Shape &x, const std::vector<std::uint32_t> &perm) {
   if (perm.size() < x.depth()) {
     PRIMITIV_THROW_ERROR(
-        "Invalid permutation. shape: " << x.to_string()
-        << ", perm: {" << string_utils::join(perm, ",") << "}");
+        "Invalid perm to permute. shape: " << x.to_string()
+        << ", perm.size(): " << perm.size());
   }
   std::vector<std::uint32_t> dims(perm.size());
   std::vector<bool> picked(perm.size());
   for (std::uint32_t i = 0; i < perm.size(); ++i) {
     if (perm[i] >= perm.size()) {
       PRIMITIV_THROW_ERROR(
-          "Invalid permutation. shape: " << x.to_string()
-          << ", perm: {" << string_utils::join(perm, ",") << "}");
+          "Invalid perm to permute. shape: " << x.to_string()
+          << ", perm.size(): " << perm.size()
+          << ", perm[" << i << "]: " << perm[i]);
     }
     if (picked[perm[i]]) {
       PRIMITIV_THROW_ERROR(
-          "Invalid permutation. shape: " << x.to_string()
-          << ", perm: {" << string_utils::join(perm, ",") << "}");
+          "Invalid perm to permute. shape: " << x.to_string()
+          << ", perm[" << i << "]: " << perm[i]
+          << " (duplicated)");
     }
     picked[perm[i]] = true;
     dims[i] = x[perm[i]];

--- a/primitiv/core/shape_ops.cc
+++ b/primitiv/core/shape_ops.cc
@@ -122,6 +122,33 @@ Shape transpose(const Shape &x) {
   return Shape({x[1], x[0]}, x.batch());
 }
 
+Shape permute_dims(const Shape &x, const std::vector<std::uint32_t> &perm) {
+  if (perm.size() < x.depth()) {
+    PRIMITIV_THROW_ERROR(
+        "Invalid perm to permute. shape: " << x.to_string()
+        << ", perm.size(): " << perm.size());
+  }
+  std::vector<std::uint32_t> dims(perm.size());
+  std::vector<bool> picked(perm.size());
+  for (std::uint32_t i = 0; i < perm.size(); ++i) {
+    if (perm[i] >= perm.size()) {
+      PRIMITIV_THROW_ERROR(
+          "Invalid perm to permute. shape: " << x.to_string()
+          << ", perm.size(): " << perm.size()
+          << ", perm[" << i << "]: " << perm[i]);
+    }
+    if (picked[perm[i]]) {
+      PRIMITIV_THROW_ERROR(
+          "Invalid perm to permute. shape: " << x.to_string()
+          << ", perm[" << i << "]: " << perm[i]
+          << " (duplicated)");
+    }
+    picked[perm[i]] = true;
+    dims[i] = x[perm[i]];
+  }
+  return Shape(dims, x.batch());
+}
+
 Shape matmul(const Shape &l, const Shape &r) {
   if (!l.is_matrix() || !r.is_matrix() || l[1] != r[0] ||
       !l.has_compatible_batch(r)) {

--- a/primitiv/core/shape_ops.cc
+++ b/primitiv/core/shape_ops.cc
@@ -4,6 +4,7 @@
 
 #include <primitiv/core/error.h>
 #include <primitiv/core/shape_ops.h>
+#include <primitiv/core/string_utils.h>
 
 namespace primitiv {
 namespace shape_ops {
@@ -125,23 +126,21 @@ Shape transpose(const Shape &x) {
 Shape permute_dims(const Shape &x, const std::vector<std::uint32_t> &perm) {
   if (perm.size() < x.depth()) {
     PRIMITIV_THROW_ERROR(
-        "Invalid perm to permute. shape: " << x.to_string()
-        << ", perm.size(): " << perm.size());
+        "Invalid permutation. shape: " << x.to_string()
+        << ", perm: {" << string_utils::join(perm, ",") << "}");
   }
   std::vector<std::uint32_t> dims(perm.size());
   std::vector<bool> picked(perm.size());
   for (std::uint32_t i = 0; i < perm.size(); ++i) {
     if (perm[i] >= perm.size()) {
       PRIMITIV_THROW_ERROR(
-          "Invalid perm to permute. shape: " << x.to_string()
-          << ", perm.size(): " << perm.size()
-          << ", perm[" << i << "]: " << perm[i]);
+          "Invalid permutation. shape: " << x.to_string()
+          << ", perm: {" << string_utils::join(perm, ",") << "}");
     }
     if (picked[perm[i]]) {
       PRIMITIV_THROW_ERROR(
-          "Invalid perm to permute. shape: " << x.to_string()
-          << ", perm[" << i << "]: " << perm[i]
-          << " (duplicated)");
+          "Invalid permutation. shape: " << x.to_string()
+          << ", perm: {" << string_utils::join(perm, ",") << "}");
     }
     picked[perm[i]] = true;
     dims[i] = x[perm[i]];

--- a/primitiv/core/shape_ops.h
+++ b/primitiv/core/shape_ops.h
@@ -92,6 +92,13 @@ Shape pick(const Shape &x, const std::vector<std::uint32_t> &ids, std::uint32_t 
  */
 Shape transpose(const Shape &x);
 
+/**
+ * Calculates a permuted shape.
+ * @param x A shape.
+ * @return Calculated shape.
+ */
+Shape permute_dims(const Shape &x, const std::vector<std::uint32_t> &perm);
+
 /** Calculates a shape of matrix products.
  * @param l Shape of the left hand side.
  * @param r Shape of the right hand side.

--- a/primitiv/core/string_utils.h
+++ b/primitiv/core/string_utils.h
@@ -12,24 +12,21 @@ namespace primitiv {
 namespace string_utils {
 
 /**
- * Concatenates all items in the vector using delimiter.
- * @param strs Items to be concatenated.
+ * Concatenates all strings in the vector using delimiter.
+ * @param strs Strings to be concatenated.
  * @param delim Delimiter.
  * @return A concatenated string with following format:
  *           0 contents        : ""
- *           1 content         : xs[0]
- *           2 contents or more: xs[0] + delim + xs[1] + delim + ...
- *         If items are not strings, each item is converted to a string using
- *         the default format of stringstream.
+ *           1 content         : strs[0]
+ *           2 contents or more: strs[0] + delim + strs[1] + delim + ...
  */
-template<typename T>
 inline std::string join(
-    const std::vector<T> &xs,
+    const std::vector<std::string> &strs,
     const std::string &delim) {
-  if (xs.empty()) return std::string();
+  if (strs.empty()) return std::string();
   std::stringstream ss;
-  ss << xs[0];
-  for (std::uint32_t i = 1; i < xs.size(); ++i) ss << delim << xs[i];
+  ss << strs[0];
+  for (std::uint32_t i = 1; i < strs.size(); ++i) ss << delim << strs[i];
   return ss.str();
 }
 

--- a/primitiv/core/string_utils.h
+++ b/primitiv/core/string_utils.h
@@ -12,21 +12,24 @@ namespace primitiv {
 namespace string_utils {
 
 /**
- * Concatenates all strings in the vector using delimiter.
- * @param strs Strings to be concatenated.
+ * Concatenates all items in the vector using delimiter.
+ * @param strs Items to be concatenated.
  * @param delim Delimiter.
  * @return A concatenated string with following format:
  *           0 contents        : ""
- *           1 content         : strs[0]
- *           2 contents or more: strs[0] + delim + strs[1] + delim + ...
+ *           1 content         : xs[0]
+ *           2 contents or more: xs[0] + delim + xs[1] + delim + ...
+ *         If items are not strings, each item is converted to a string using
+ *         the default format of stringstream.
  */
+template<typename T>
 inline std::string join(
-    const std::vector<std::string> &strs,
+    const std::vector<T> &xs,
     const std::string &delim) {
-  if (strs.empty()) return std::string();
+  if (xs.empty()) return std::string();
   std::stringstream ss;
-  ss << strs[0];
-  for (std::uint32_t i = 1; i < strs.size(); ++i) ss << delim << strs[i];
+  ss << xs[0];
+  for (std::uint32_t i = 1; i < xs.size(); ++i) ss << delim << xs[i];
   return ss.str();
 }
 

--- a/primitiv/core/tensor_funcs.cc
+++ b/primitiv/core/tensor_funcs.cc
@@ -198,6 +198,11 @@ Tensor transpose(const Tensor &x) {
 }
 
 template<>
+Tensor permute_dims(const Tensor &x, const std::vector<std::uint32_t> &perm) {
+  return x.device().permute_dims_fw(x, perm);
+}
+
+template<>
 Tensor matmul(const Tensor &a, const Tensor &b) {
   return a.device().matmul_fw(a, b);
 }

--- a/primitiv/devices/cuda/device.h
+++ b/primitiv/devices/cuda/device.h
@@ -103,6 +103,7 @@ private:
   void cos_fw_impl(const Tensor &x, Tensor &y) override;
   void tan_fw_impl(const Tensor &x, Tensor &y) override;
   void transpose_fw_impl(const Tensor &x, Tensor &y) override;
+  void permute_dims_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) override;
 
   void abs_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void sqrt_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
@@ -115,6 +116,7 @@ private:
   void cos_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void tan_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void transpose_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
+  void permute_dims_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx) override;
 
   void add_const_fw_impl(const Tensor &x, float k, Tensor &y) override;
   void subtract_const_r_fw_impl(const Tensor &x, float k, Tensor &y) override;

--- a/primitiv/devices/cuda/ops/permute_dims.cu
+++ b/primitiv/devices/cuda/ops/permute_dims.cu
@@ -22,6 +22,8 @@ __global__ void permute_dims_fw_dev(
   if (i < size) {
     std::uint32_t tmp = i;
     std::uint32_t j = 0;
+    // TODO(vbkaisetsu):
+    // Implove implementation
     for (std::uint32_t d = 0; d < ndims; ++d) {
       const std::uint32_t p = tmp / permute_dims_x_strides[d];
       tmp -= p * permute_dims_x_strides[d];
@@ -40,6 +42,8 @@ __global__ void permute_dims_bw_dev(
   if (i < size) {
     std::uint32_t tmp = i;
     std::uint32_t j = 0;
+    // TODO(vbkaisetsu):
+    // Implove implementation
     for (std::uint32_t d = 0; d < ndims; ++d) {
       const std::uint32_t p = tmp / permute_dims_x_strides[d];
       tmp -= p * permute_dims_x_strides[d];

--- a/primitiv/devices/cuda/ops/permute_dims.cu
+++ b/primitiv/devices/cuda/ops/permute_dims.cu
@@ -1,0 +1,113 @@
+#include <primitiv/config.h>
+
+#include <primitiv/devices/cuda/device.h>
+#include <primitiv/devices/cuda/ops/common.h>
+#include <primitiv/internal/cuda/utils.h>
+
+namespace {
+
+__global__ void permute_dims_fw_dev(
+    const float *px, const std::uint32_t ndims, const std::uint32_t *x_strides,
+    const std::uint32_t *y_strides, const std::uint32_t size, float *py) {
+  const std::uint32_t i = IDX;
+  const std::uint32_t bid_z = IDY;
+  const std::uint32_t ofs = bid_z * size;
+  if (i < size) {
+    std::uint32_t tmp = i;
+    std::uint32_t j = 0;
+    for (std::uint32_t d = 0; d < ndims; ++d) {
+      const std::uint32_t p = tmp / x_strides[d];
+      tmp -= p * x_strides[d];
+      j += p * y_strides[d];
+    }
+    py[ofs + j] = px[ofs + i];
+  }
+}
+
+__global__ void permute_dims_bw_dev(
+    const float *py, const std::uint32_t ndims, const std::uint32_t *x_strides,
+    const std::uint32_t *y_strides, const std::uint32_t size, float *px) {
+  const std::uint32_t i = IDX;
+  const std::uint32_t bid_z = IDY;
+  const std::uint32_t ofs = bid_z * size;
+  if (i < size) {
+    std::uint32_t tmp = i;
+    std::uint32_t j = 0;
+    for (std::uint32_t d = 0; d < ndims; ++d) {
+      const std::uint32_t p = tmp / x_strides[d];
+      tmp -= p * x_strides[d];
+      j += p * y_strides[d];
+    }
+    px[ofs + i] += py[ofs + j];
+  }
+}
+
+}  // namespace
+
+namespace primitiv {
+namespace devices {
+
+void CUDA::transpose_fw_impl(
+    const Tensor &x, const std::vector<std::uint32_t> &perm,
+    Tensor &y) {
+  const std::uint32_t ndims = perm.size();
+  const std::uint32_t bs = x.shape().batch();
+  const std::uint32_t size = x.shape().volume();
+  const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = x.shape().lower_volume(i);
+    y_strides[ndims - perm[i] - 1] = y.shape().lower_volume(i);
+  }
+  std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * x_strides.size());
+  std::shared_ptr<void> y_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * y_strides.size());
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  CUDA_CALL(::cudaMemcpy(
+        x_strides_buf.get(), x_strides.data(), sizeof(std::uint32_t) * x_strides.size(),
+        cudaMemcpyHostToDevice));
+  CUDA_CALL(::cudaMemcpy(
+        y_strides_buf.get(), y_strides.data(), sizeof(std::uint32_t) * y_strides.size(),
+        cudaMemcpyHostToDevice));
+  ::permute_dims_fw_dev<<<dim3(g1, bs), dim1_x_>>>(
+      CDATA(x), ndims,
+      static_cast<const std::uint32_t *>(x_strides_buf.get()),
+      static_cast<const std::uint32_t *>(y_strides_buf.get()),
+      size, MDATA(y));
+}
+
+void CUDA::transpose_bw_impl(
+    const Tensor &, const Tensor &, const Tensor &gy,
+    const std::vector<std::uint32_t> &perm, Tensor &gx) {
+  const std::uint32_t ndims = perm.size();
+  const std::uint32_t bs = gx.shape().batch();
+  const std::uint32_t size = gx.shape().volume();
+  const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = gx.shape().lower_volume(i);
+    y_strides[ndims - perm[i] - 1] = gy.shape().lower_volume(i);
+  }
+  std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * x_strides.size());
+  std::shared_ptr<void> y_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * y_strides.size());
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  CUDA_CALL(::cudaMemcpy(
+        x_strides_buf.get(), x_strides.data(), sizeof(std::uint32_t) * x_strides.size(),
+        cudaMemcpyHostToDevice));
+  CUDA_CALL(::cudaMemcpy(
+        y_strides_buf.get(), y_strides.data(), sizeof(std::uint32_t) * y_strides.size(),
+        cudaMemcpyHostToDevice));
+  ::permute_dims_bw_dev<<<dim3(g1, bs), dim1_x_>>>(
+      CDATA(gy), ndims,
+      static_cast<const std::uint32_t *>(x_strides_buf.get()),
+      static_cast<const std::uint32_t *>(y_strides_buf.get()),
+      size, MDATA(gx));
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/devices/cuda/ops/permute_dims.cu
+++ b/primitiv/devices/cuda/ops/permute_dims.cu
@@ -67,9 +67,13 @@ void CUDA::permute_dims_fw_impl(
   const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
   std::vector<std::uint32_t> x_strides(ndims);
   std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
   for (std::uint32_t i = 0; i < ndims; ++i) {
-    x_strides[ndims - i - 1] = x.shape().lower_volume(i);
-    y_strides[ndims - perm[i] - 1] = y.shape().lower_volume(i);
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= x.shape()[i];
+    y_stride_tmp *= y.shape()[i];
   }
   CUDA_CALL(::cudaSetDevice(dev_id_));
   CUDA_CALL(::cudaMemcpyToSymbol(
@@ -91,9 +95,13 @@ void CUDA::permute_dims_bw_impl(
   const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
   std::vector<std::uint32_t> x_strides(ndims);
   std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
   for (std::uint32_t i = 0; i < ndims; ++i) {
-    x_strides[ndims - i - 1] = gx.shape().lower_volume(i);
-    y_strides[ndims - perm[i] - 1] = gy.shape().lower_volume(i);
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= gx.shape()[i];
+    y_stride_tmp *= gy.shape()[i];
   }
   CUDA_CALL(::cudaSetDevice(dev_id_));
   CUDA_CALL(::cudaMemcpyToSymbol(

--- a/primitiv/devices/cuda/ops/permute_dims.cu
+++ b/primitiv/devices/cuda/ops/permute_dims.cu
@@ -47,7 +47,7 @@ __global__ void permute_dims_bw_dev(
 namespace primitiv {
 namespace devices {
 
-void CUDA::transpose_fw_impl(
+void CUDA::permute_dims_fw_impl(
     const Tensor &x, const std::vector<std::uint32_t> &perm,
     Tensor &y) {
   const std::uint32_t ndims = perm.size();
@@ -78,7 +78,7 @@ void CUDA::transpose_fw_impl(
       size, MDATA(y));
 }
 
-void CUDA::transpose_bw_impl(
+void CUDA::permute_dims_bw_impl(
     const Tensor &, const Tensor &, const Tensor &gy,
     const std::vector<std::uint32_t> &perm, Tensor &gx) {
   const std::uint32_t ndims = perm.size();

--- a/primitiv/devices/cuda16/device.h
+++ b/primitiv/devices/cuda16/device.h
@@ -105,6 +105,7 @@ private:
   void cos_fw_impl(const Tensor &x, Tensor &y) override;
   void tan_fw_impl(const Tensor &x, Tensor &y) override;
   void transpose_fw_impl(const Tensor &x, Tensor &y) override;
+  void permute_dims_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) override;
 
   void abs_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void sqrt_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
@@ -117,6 +118,7 @@ private:
   void cos_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void tan_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void transpose_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
+  void permute_dims_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx) override;
 
   void add_const_fw_impl(const Tensor &x, float k, Tensor &y) override;
   void subtract_const_r_fw_impl(const Tensor &x, float k, Tensor &y) override;

--- a/primitiv/devices/cuda16/ops/permute_dims.cu
+++ b/primitiv/devices/cuda16/ops/permute_dims.cu
@@ -69,9 +69,13 @@ void CUDA16::permute_dims_fw_impl(
   const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
   std::vector<std::uint32_t> x_strides(ndims);
   std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
   for (std::uint32_t i = 0; i < ndims; ++i) {
-    x_strides[ndims - i - 1] = x.shape().lower_volume(i);
-    y_strides[ndims - perm[i] - 1] = y.shape().lower_volume(i);
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= x.shape()[i];
+    y_stride_tmp *= y.shape()[i];
   }
   CUDA_CALL(::cudaSetDevice(dev_id_));
   CUDA_CALL(::cudaMemcpyToSymbol(
@@ -93,9 +97,13 @@ void CUDA16::permute_dims_bw_impl(
   const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
   std::vector<std::uint32_t> x_strides(ndims);
   std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
   for (std::uint32_t i = 0; i < ndims; ++i) {
-    x_strides[ndims - i - 1] = gx.shape().lower_volume(i);
-    y_strides[ndims - perm[i] - 1] = gy.shape().lower_volume(i);
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= gx.shape()[i];
+    y_stride_tmp *= gy.shape()[i];
   }
   CUDA_CALL(::cudaSetDevice(dev_id_));
   CUDA_CALL(::cudaMemcpyToSymbol(

--- a/primitiv/devices/cuda16/ops/permute_dims.cu
+++ b/primitiv/devices/cuda16/ops/permute_dims.cu
@@ -1,0 +1,115 @@
+#include <primitiv/config.h>
+
+#include <primitiv/devices/cuda16/device.h>
+#include <primitiv/devices/cuda16/ops/common.h>
+#include <primitiv/internal/cuda/utils.h>
+
+namespace {
+
+__global__ void permute_dims_fw_dev(
+    const half *px, const std::uint32_t ndims, const std::uint32_t *x_strides,
+    const std::uint32_t *y_strides, const std::uint32_t size, half *py) {
+  const std::uint32_t i = IDX;
+  const std::uint32_t bid_z = IDY;
+  const std::uint32_t ofs = bid_z * size;
+  if (i < size) {
+    std::uint32_t tmp = i;
+    std::uint32_t j = 0;
+    for (std::uint32_t d = 0; d < ndims; ++d) {
+      const std::uint32_t p = tmp / x_strides[d];
+      tmp -= p * x_strides[d];
+      j += p * y_strides[d];
+    }
+    py[ofs + j] = px[ofs + i];
+  }
+}
+
+__global__ void permute_dims_bw_dev(
+    const half *py, const std::uint32_t ndims, const std::uint32_t *x_strides,
+    const std::uint32_t *y_strides, const std::uint32_t size, half *px) {
+  const std::uint32_t i = IDX;
+  const std::uint32_t bid_z = IDY;
+  const std::uint32_t ofs = bid_z * size;
+  if (i < size) {
+    std::uint32_t tmp = i;
+    std::uint32_t j = 0;
+    for (std::uint32_t d = 0; d < ndims; ++d) {
+      const std::uint32_t p = tmp / x_strides[d];
+      tmp -= p * x_strides[d];
+      j += p * y_strides[d];
+    }
+    const std::size_t ox = ofs + i;
+    const std::size_t oy = ofs + j;
+    INPLACE_ADD(px + ox, ::__half2float(py[oy]));
+  }
+}
+
+}  // namespace
+
+namespace primitiv {
+namespace devices {
+
+void CUDA16::permute_dims_fw_impl(
+    const Tensor &x, const std::vector<std::uint32_t> &perm,
+    Tensor &y) {
+  const std::uint32_t ndims = perm.size();
+  const std::uint32_t bs = x.shape().batch();
+  const std::uint32_t size = x.shape().volume();
+  const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = x.shape().lower_volume(i);
+    y_strides[ndims - perm[i] - 1] = y.shape().lower_volume(i);
+  }
+  std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * x_strides.size());
+  std::shared_ptr<void> y_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * y_strides.size());
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  CUDA_CALL(::cudaMemcpy(
+        x_strides_buf.get(), x_strides.data(), sizeof(std::uint32_t) * x_strides.size(),
+        cudaMemcpyHostToDevice));
+  CUDA_CALL(::cudaMemcpy(
+        y_strides_buf.get(), y_strides.data(), sizeof(std::uint32_t) * y_strides.size(),
+        cudaMemcpyHostToDevice));
+  ::permute_dims_fw_dev<<<dim3(g1, bs), dim1_x_>>>(
+      CDATA(half, x), ndims,
+      static_cast<const std::uint32_t *>(x_strides_buf.get()),
+      static_cast<const std::uint32_t *>(y_strides_buf.get()),
+      size, MDATA(half, y));
+}
+
+void CUDA16::permute_dims_bw_impl(
+    const Tensor &, const Tensor &, const Tensor &gy,
+    const std::vector<std::uint32_t> &perm, Tensor &gx) {
+  const std::uint32_t ndims = perm.size();
+  const std::uint32_t bs = gx.shape().batch();
+  const std::uint32_t size = gx.shape().volume();
+  const std::uint32_t g1 = GRID_SIZE(size, dim1_x_);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = gx.shape().lower_volume(i);
+    y_strides[ndims - perm[i] - 1] = gy.shape().lower_volume(i);
+  }
+  std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * x_strides.size());
+  std::shared_ptr<void> y_strides_buf = state_->pool.allocate(
+      sizeof(std::uint32_t) * y_strides.size());
+  CUDA_CALL(::cudaSetDevice(dev_id_));
+  CUDA_CALL(::cudaMemcpy(
+        x_strides_buf.get(), x_strides.data(), sizeof(std::uint32_t) * x_strides.size(),
+        cudaMemcpyHostToDevice));
+  CUDA_CALL(::cudaMemcpy(
+        y_strides_buf.get(), y_strides.data(), sizeof(std::uint32_t) * y_strides.size(),
+        cudaMemcpyHostToDevice));
+  ::permute_dims_bw_dev<<<dim3(g1, bs), dim1_x_>>>(
+      CDATA(half, gy), ndims,
+      static_cast<const std::uint32_t *>(x_strides_buf.get()),
+      static_cast<const std::uint32_t *>(y_strides_buf.get()),
+      size, MDATA(half, gx));
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/devices/eigen/device.h
+++ b/primitiv/devices/eigen/device.h
@@ -66,6 +66,7 @@ private:
   void cos_fw_impl(const Tensor &x, Tensor &y) override;
   void tan_fw_impl(const Tensor &x, Tensor &y) override;
   void transpose_fw_impl(const Tensor &x, Tensor &y) override;
+  void permute_dims_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) override;
 
   void abs_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void sqrt_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
@@ -78,6 +79,7 @@ private:
   void cos_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void tan_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void transpose_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
+  void permute_dims_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx) override;
 
   void add_const_fw_impl(const Tensor &x, float k, Tensor &y) override;
   void subtract_const_r_fw_impl(const Tensor &x, float k, Tensor &y) override;

--- a/primitiv/devices/eigen/ops/permute_dims.cc
+++ b/primitiv/devices/eigen/ops/permute_dims.cc
@@ -15,19 +15,24 @@ void Eigen::permute_dims_fw_impl(
     const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) {
   const std::uint32_t volume = x.shape().volume();
   const std::uint32_t bs = x.shape().batch();
+  const std::uint32_t ndims = perm.size();
   float *dest = MDATA(y);
   const float *src = CDATA(x);
-  std::vector<std::uint32_t> x_strides(perm.size());
-  std::vector<std::uint32_t> y_strides(perm.size());
-  for (std::uint32_t i = 0; i < perm.size(); ++i) {
-    x_strides[perm.size() - i - 1] = x.shape().lower_volume(i);
-    y_strides[perm.size() - perm[i] - 1] = y.shape().lower_volume(i);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= x.shape()[i];
+    y_stride_tmp *= y.shape()[i];
   }
   for (std::uint32_t k = 0; k < bs; ++k) {
     for (std::uint32_t i = 0; i < volume; ++i) {
       std::uint32_t tmp = i;
       std::uint32_t j = 0;
-      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+      for (std::uint32_t d = 0; d < ndims; ++d) {
         const std::uint32_t p = tmp / x_strides[d];
         tmp -= p * x_strides[d];
         j += p * y_strides[d];
@@ -44,19 +49,24 @@ void Eigen::permute_dims_bw_impl(
     const std::vector<std::uint32_t> &perm, Tensor &gx) {
   const std::uint32_t volume = gx.shape().volume();
   const std::uint32_t bs = gx.shape().batch();
+  const std::uint32_t ndims = perm.size();
   float *pgx = MDATA(gx);
   const float *pgy = CDATA(gy);
-  std::vector<std::uint32_t> x_strides(perm.size());
-  std::vector<std::uint32_t> y_strides(perm.size());
-  for (std::uint32_t i = 0; i < perm.size(); ++i) {
-    x_strides[perm.size() - i - 1] = gx.shape().lower_volume(i);
-    y_strides[perm.size() - perm[i] - 1] = gy.shape().lower_volume(i);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= gx.shape()[i];
+    y_stride_tmp *= gy.shape()[i];
   }
   for (std::uint32_t k = 0; k < bs; ++k) {
     for (std::uint32_t i = 0; i < volume; ++i) {
       std::uint32_t tmp = i;
       std::uint32_t j = 0;
-      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+      for (std::uint32_t d = 0; d < ndims; ++d) {
         const std::uint32_t p = tmp / x_strides[d];
         tmp -= p * x_strides[d];
         j += p * y_strides[d];

--- a/primitiv/devices/eigen/ops/permute_dims.cc
+++ b/primitiv/devices/eigen/ops/permute_dims.cc
@@ -1,0 +1,72 @@
+#include <primitiv/config.h>
+
+#include <primitiv/devices/eigen/device.h>
+#include <primitiv/devices/eigen/ops/common.h>
+
+namespace primitiv {
+namespace devices {
+
+// TODO(vbkaisetsu):
+// Implove implementations.
+// These code is identical with the Naive implementation and extremely
+// slow.
+
+void Eigen::permute_dims_fw_impl(
+    const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) {
+  const std::uint32_t volume = x.shape().volume();
+  const std::uint32_t bs = x.shape().batch();
+  float *dest = MDATA(y);
+  const float *src = CDATA(x);
+  std::vector<std::uint32_t> x_strides(perm.size());
+  std::vector<std::uint32_t> y_strides(perm.size());
+  for (std::uint32_t i = 0; i < perm.size(); ++i) {
+    x_strides[perm.size() - i - 1] = x.shape().lower_volume(i);
+    y_strides[perm.size() - perm[i] - 1] = y.shape().lower_volume(i);
+  }
+  for (std::uint32_t k = 0; k < bs; ++k) {
+    for (std::uint32_t i = 0; i < volume; ++i) {
+      std::uint32_t tmp = i;
+      std::uint32_t j = 0;
+      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+        const std::uint32_t p = tmp / x_strides[d];
+        tmp -= p * x_strides[d];
+        j += p * y_strides[d];
+      }
+      dest[j] = src[i];
+    }
+    src += volume;
+    dest += volume;
+  }
+}
+
+void Eigen::permute_dims_bw_impl(
+    const Tensor &, const Tensor &, const Tensor &gy,
+    const std::vector<std::uint32_t> &perm, Tensor &gx) {
+  const std::uint32_t volume = gx.shape().volume();
+  const std::uint32_t bs = gx.shape().batch();
+  float *pgx = MDATA(gx);
+  const float *pgy = CDATA(gy);
+  std::vector<std::uint32_t> x_strides(perm.size());
+  std::vector<std::uint32_t> y_strides(perm.size());
+  for (std::uint32_t i = 0; i < perm.size(); ++i) {
+    x_strides[perm.size() - i - 1] = gx.shape().lower_volume(i);
+    y_strides[perm.size() - perm[i] - 1] = gy.shape().lower_volume(i);
+  }
+  for (std::uint32_t k = 0; k < bs; ++k) {
+    for (std::uint32_t i = 0; i < volume; ++i) {
+      std::uint32_t tmp = i;
+      std::uint32_t j = 0;
+      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+        const std::uint32_t p = tmp / x_strides[d];
+        tmp -= p * x_strides[d];
+        j += p * y_strides[d];
+      }
+      pgx[i] += pgy[j];
+    }
+    pgx += volume;
+    pgy += volume;
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/devices/naive/device.h
+++ b/primitiv/devices/naive/device.h
@@ -66,6 +66,7 @@ private:
   void cos_fw_impl(const Tensor &x, Tensor &y) override;
   void tan_fw_impl(const Tensor &x, Tensor &y) override;
   void transpose_fw_impl(const Tensor &x, Tensor &y) override;
+  void permute_dims_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) override;
 
   void abs_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void sqrt_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
@@ -78,6 +79,7 @@ private:
   void cos_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void tan_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void transpose_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
+  void permute_dims_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx) override;
 
   void add_const_fw_impl(const Tensor &x, float k, Tensor &y) override;
   void subtract_const_r_fw_impl(const Tensor &x, float k, Tensor &y) override;

--- a/primitiv/devices/naive/ops/permute_dims.cc
+++ b/primitiv/devices/naive/ops/permute_dims.cc
@@ -1,0 +1,67 @@
+#include <primitiv/config.h>
+
+#include <primitiv/devices/naive/device.h>
+#include <primitiv/devices/naive/ops/common.h>
+
+namespace primitiv {
+namespace devices {
+
+void Naive::permute_dims_fw_impl(
+    const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) {
+  const std::uint32_t volume = x.shape().volume();
+  const std::uint32_t bs = x.shape().batch();
+  float *dest = MDATA(y);
+  const float *src = CDATA(x);
+  std::vector<std::uint32_t> x_strides(perm.size());
+  std::vector<std::uint32_t> y_strides(perm.size());
+  for (std::uint32_t i = 0; i < perm.size(); ++i) {
+    x_strides[perm.size() - i - 1] = x.shape().lower_volume(i);
+    y_strides[perm.size() - perm[i] - 1] = y.shape().lower_volume(i);
+  }
+  for (std::uint32_t k = 0; k < bs; ++k) {
+    for (std::uint32_t i = 0; i < volume; ++i) {
+      std::uint32_t tmp = i;
+      std::uint32_t j = 0;
+      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+        const std::uint32_t p = tmp / x_strides[d];
+        tmp -= p * x_strides[d];
+        j += p * y_strides[d];
+      }
+      dest[j] = src[i];
+    }
+    src += volume;
+    dest += volume;
+  }
+}
+
+void Naive::permute_dims_bw_impl(
+    const Tensor &, const Tensor &, const Tensor &gy,
+    const std::vector<std::uint32_t> &perm, Tensor &gx) {
+  const std::uint32_t volume = gx.shape().volume();
+  const std::uint32_t bs = gx.shape().batch();
+  float *pgx = MDATA(gx);
+  const float *pgy = CDATA(gy);
+  std::vector<std::uint32_t> x_strides(perm.size());
+  std::vector<std::uint32_t> y_strides(perm.size());
+  for (std::uint32_t i = 0; i < perm.size(); ++i) {
+    x_strides[perm.size() - i - 1] = gx.shape().lower_volume(i);
+    y_strides[perm.size() - perm[i] - 1] = gy.shape().lower_volume(i);
+  }
+  for (std::uint32_t k = 0; k < bs; ++k) {
+    for (std::uint32_t i = 0; i < volume; ++i) {
+      std::uint32_t tmp = i;
+      std::uint32_t j = 0;
+      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+        const std::uint32_t p = tmp / x_strides[d];
+        tmp -= p * x_strides[d];
+        j += p * y_strides[d];
+      }
+      pgx[i] += pgy[j];
+    }
+    pgx += volume;
+    pgy += volume;
+  }
+}
+
+}  // namespace devices
+}  // namespace primitiv

--- a/primitiv/devices/naive/ops/permute_dims.cc
+++ b/primitiv/devices/naive/ops/permute_dims.cc
@@ -10,19 +10,24 @@ void Naive::permute_dims_fw_impl(
     const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) {
   const std::uint32_t volume = x.shape().volume();
   const std::uint32_t bs = x.shape().batch();
+  const std::uint32_t ndims = perm.size();
   float *dest = MDATA(y);
   const float *src = CDATA(x);
-  std::vector<std::uint32_t> x_strides(perm.size());
-  std::vector<std::uint32_t> y_strides(perm.size());
-  for (std::uint32_t i = 0; i < perm.size(); ++i) {
-    x_strides[perm.size() - i - 1] = x.shape().lower_volume(i);
-    y_strides[perm.size() - perm[i] - 1] = y.shape().lower_volume(i);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= x.shape()[i];
+    y_stride_tmp *= y.shape()[i];
   }
   for (std::uint32_t k = 0; k < bs; ++k) {
     for (std::uint32_t i = 0; i < volume; ++i) {
       std::uint32_t tmp = i;
       std::uint32_t j = 0;
-      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+      for (std::uint32_t d = 0; d < ndims; ++d) {
         const std::uint32_t p = tmp / x_strides[d];
         tmp -= p * x_strides[d];
         j += p * y_strides[d];
@@ -39,19 +44,24 @@ void Naive::permute_dims_bw_impl(
     const std::vector<std::uint32_t> &perm, Tensor &gx) {
   const std::uint32_t volume = gx.shape().volume();
   const std::uint32_t bs = gx.shape().batch();
+  const std::uint32_t ndims = perm.size();
   float *pgx = MDATA(gx);
   const float *pgy = CDATA(gy);
-  std::vector<std::uint32_t> x_strides(perm.size());
-  std::vector<std::uint32_t> y_strides(perm.size());
-  for (std::uint32_t i = 0; i < perm.size(); ++i) {
-    x_strides[perm.size() - i - 1] = gx.shape().lower_volume(i);
-    y_strides[perm.size() - perm[i] - 1] = gy.shape().lower_volume(i);
+  std::vector<std::uint32_t> x_strides(ndims);
+  std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
+  for (std::uint32_t i = 0; i < ndims; ++i) {
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= gx.shape()[i];
+    y_stride_tmp *= gy.shape()[i];
   }
   for (std::uint32_t k = 0; k < bs; ++k) {
     for (std::uint32_t i = 0; i < volume; ++i) {
       std::uint32_t tmp = i;
       std::uint32_t j = 0;
-      for (std::uint32_t d = 0; d < perm.size(); ++d) {
+      for (std::uint32_t d = 0; d < ndims; ++d) {
         const std::uint32_t p = tmp / x_strides[d];
         tmp -= p * x_strides[d];
         j += p * y_strides[d];

--- a/primitiv/devices/opencl/device.cc
+++ b/primitiv/devices/opencl/device.cc
@@ -1150,6 +1150,10 @@ void OpenCL::transpose_fw_impl(const Tensor &x, Tensor &y) {
         state_->transpose_fw_group_size_y, 1));
 }
 
+// TODO(vbkaisetsu):
+// Implove implementation of permute_dims.
+// This function uses for-loops in the kernel code. It becomes slower than
+// no-loop implementation.
 void OpenCL::permute_dims_fw_impl(
     const Tensor &x, const std::vector<std::uint32_t> &perm,
     Tensor &y) {

--- a/primitiv/devices/opencl/device.cc
+++ b/primitiv/devices/opencl/device.cc
@@ -1170,10 +1170,12 @@ void OpenCL::permute_dims_fw_impl(
   }
   std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
       sizeof(std::uint32_t) * x_strides.size());
-  ::write_buffer(state_->queue, ::get_buffer(x_strides_buf), x_strides.data(), x_strides.size());
   std::shared_ptr<void> y_strides_buf = state_->pool.allocate(
       sizeof(std::uint32_t) * y_strides.size());
-  ::write_buffer(state_->queue, ::get_buffer(y_strides_buf), y_strides.data(), y_strides.size());
+  if (perm.size() != 0) {
+    ::write_buffer(state_->queue, ::get_buffer(x_strides_buf), x_strides.data(), x_strides.size());
+    ::write_buffer(state_->queue, ::get_buffer(y_strides_buf), y_strides.data(), y_strides.size());
+  }
   state_->permute_dims_fw_kernel.setArg(0, CDATA(x));
   state_->permute_dims_fw_kernel.setArg(1, ndims);
   state_->permute_dims_fw_kernel.setArg(2, ::get_buffer(x_strides_buf));
@@ -1273,10 +1275,12 @@ void OpenCL::permute_dims_bw_impl(
   }
   std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
       sizeof(std::uint32_t) * x_strides.size());
-  ::write_buffer(state_->queue, ::get_buffer(x_strides_buf), x_strides.data(), x_strides.size());
   std::shared_ptr<void> y_strides_buf = state_->pool.allocate(
       sizeof(std::uint32_t) * y_strides.size());
-  ::write_buffer(state_->queue, ::get_buffer(y_strides_buf), y_strides.data(), y_strides.size());
+  if (perm.size() != 0) {
+    ::write_buffer(state_->queue, ::get_buffer(x_strides_buf), x_strides.data(), x_strides.size());
+    ::write_buffer(state_->queue, ::get_buffer(y_strides_buf), y_strides.data(), y_strides.size());
+  }
   state_->permute_dims_bw_kernel.setArg(0, CDATA(gy));
   state_->permute_dims_bw_kernel.setArg(1, ndims);
   state_->permute_dims_bw_kernel.setArg(2, ::get_buffer(x_strides_buf));

--- a/primitiv/devices/opencl/device.cc
+++ b/primitiv/devices/opencl/device.cc
@@ -1164,9 +1164,13 @@ void OpenCL::permute_dims_fw_impl(
       size, state_->permute_dims_fw_group_size);
   std::vector<std::uint32_t> x_strides(ndims);
   std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
   for (std::uint32_t i = 0; i < ndims; ++i) {
-    x_strides[ndims - i - 1] = x.shape().lower_volume(i);
-    y_strides[ndims - perm[i] - 1] = y.shape().lower_volume(i);
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= x.shape()[i];
+    y_stride_tmp *= y.shape()[i];
   }
   std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
       sizeof(std::uint32_t) * x_strides.size());
@@ -1269,9 +1273,13 @@ void OpenCL::permute_dims_bw_impl(
       size, state_->permute_dims_bw_group_size);
   std::vector<std::uint32_t> x_strides(ndims);
   std::vector<std::uint32_t> y_strides(ndims);
+  std::uint32_t x_stride_tmp = 1;
+  std::uint32_t y_stride_tmp = 1;
   for (std::uint32_t i = 0; i < ndims; ++i) {
-    x_strides[ndims - i - 1] = gx.shape().lower_volume(i);
-    y_strides[ndims - perm[i] - 1] = gy.shape().lower_volume(i);
+    x_strides[ndims - i - 1] = x_stride_tmp;
+    y_strides[ndims - perm[i] - 1] = y_stride_tmp;
+    x_stride_tmp *= gx.shape()[i];
+    y_stride_tmp *= gy.shape()[i];
   }
   std::shared_ptr<void> x_strides_buf = state_->pool.allocate(
       sizeof(std::uint32_t) * x_strides.size());

--- a/primitiv/devices/opencl/device.h
+++ b/primitiv/devices/opencl/device.h
@@ -111,6 +111,7 @@ private:
   void cos_fw_impl(const Tensor &x, Tensor &y) override;
   void tan_fw_impl(const Tensor &x, Tensor &y) override;
   void transpose_fw_impl(const Tensor &x, Tensor &y) override;
+  void permute_dims_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &perm, Tensor &y) override;
 
   void abs_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void sqrt_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
@@ -123,6 +124,7 @@ private:
   void cos_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void tan_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
   void transpose_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, Tensor &gx) override;
+  void permute_dims_bw_impl(const Tensor &x, const Tensor &y, const Tensor &gy, const std::vector<std::uint32_t> &perm, Tensor &gx) override;
 
   void add_const_fw_impl(const Tensor &x, float k, Tensor &y) override;
   void subtract_const_r_fw_impl(const Tensor &x, float k, Tensor &y) override;

--- a/primitiv/devices/opencl/kernels.cl
+++ b/primitiv/devices/opencl/kernels.cl
@@ -446,6 +446,42 @@ kernel void transpose_bw_kernel(
   if (i < rows && j < cols) px[ofs + i + j * rows] += py[ofs + j + i * cols];
 }
 
+kernel void permute_dims_fw_kernel(
+    const global float *px, const unsigned ndims, constant unsigned *x_strides,
+    constant unsigned *y_strides, const unsigned size, global float *py) {
+  const unsigned i = get_global_id(0);
+  const unsigned bid_z = get_group_id(1);
+  const unsigned ofs = bid_z * size;
+  if (i < size) {
+    unsigned tmp = i;
+    unsigned j = 0;
+    for (unsigned d = 0; d < ndims; ++d) {
+      const unsigned p = tmp / x_strides[d];
+      tmp -= p * x_strides[d];
+      j += p * y_strides[d];
+    }
+    py[ofs + j] = px[ofs + i];
+  }
+}
+
+kernel void permute_dims_bw_kernel(
+    const global float *py, const unsigned ndims, constant unsigned *x_strides,
+    constant unsigned *y_strides, const unsigned size, global float *px) {
+  const unsigned i = get_global_id(0);
+  const unsigned bid_z = get_group_id(1);
+  const unsigned ofs = bid_z * size;
+  if (i < size) {
+    unsigned tmp = i;
+    unsigned j = 0;
+    for (unsigned d = 0; d < ndims; ++d) {
+      const unsigned p = tmp / x_strides[d];
+      tmp -= p * x_strides[d];
+      j += p * y_strides[d];
+    }
+    px[ofs + i] += py[ofs + j];
+  }
+}
+
 #define REDUCE(k, GROUP_SIZE) \
   if (GROUP_SIZE >= k << 1) { \
     if (tid < k) temp[tid] = max(temp[tid + k], temp[tid]); \

--- a/primitiv/devices/opencl/kernels.cl
+++ b/primitiv/devices/opencl/kernels.cl
@@ -455,6 +455,8 @@ kernel void permute_dims_fw_kernel(
   if (i < size) {
     unsigned tmp = i;
     unsigned j = 0;
+    // TODO(vbkaisetsu):
+    // Implove implementation
     for (unsigned d = 0; d < ndims; ++d) {
       const unsigned p = tmp / x_strides[d];
       tmp -= p * x_strides[d];
@@ -473,6 +475,8 @@ kernel void permute_dims_bw_kernel(
   if (i < size) {
     unsigned tmp = i;
     unsigned j = 0;
+    // TODO(vbkaisetsu):
+    // Implove implementation
     for (unsigned d = 0; d < ndims; ++d) {
       const unsigned p = tmp / x_strides[d];
       tmp -= p * x_strides[d];

--- a/test/operator_impl_test.cc
+++ b/test/operator_impl_test.cc
@@ -1116,6 +1116,19 @@ TEST_F(OperatorImplTest, CheckTranspose) {
   TEST_1ARG(Transpose);
 }
 
+TEST_F(OperatorImplTest, CheckPermuteDims) {
+  // y = x^T
+  // dy/dx = 1^T
+  setup_1arg();
+  const Shape ret_shape({2, 2}, 3);
+  const vector<float> ret_data {1, 3, 2, 4, 0, 0, 0, 0, -1, -3, -2, -4};
+  const vector<float> bw_grad(arg_shapes[0]->size(), 1);
+  PermuteDims node({1, 0});
+  EXPECT_EQ("PermuteDims", node.name());
+  COMMON_PROC;
+  COMMON_CHECK;
+}
+
 TEST_F(OperatorImplTest, CheckMatrixMultiply) {
   // y = a . b
   // dy/da = b^T

--- a/test/shape_ops_test.cc
+++ b/test/shape_ops_test.cc
@@ -304,26 +304,27 @@ TEST_F(ShapeOpsTest, CheckInvalidTranspose) {
 }
 
 TEST_F(ShapeOpsTest, CheckPermuteDims) {
-  EXPECT_EQ(Shape(), permute_dims({}, {1, 0}));
-  EXPECT_EQ(Shape({}, 5), permute_dims(Shape({}, 5), {1, 0}));
-  EXPECT_EQ(Shape({2}), permute_dims({1, 2}, {1, 0}));
-  EXPECT_EQ(Shape({2}, 5), permute_dims(Shape({1, 2}, 5), {1, 0}));
-  EXPECT_EQ(Shape({1, 2}), permute_dims({2}, {1, 0}));
-  EXPECT_EQ(Shape({1, 2}, 5), permute_dims(Shape({2}, 5), {1, 0}));
-  EXPECT_EQ(Shape({2, 3}), permute_dims({3, 2}, {1, 0}));
-  EXPECT_EQ(Shape({2, 3}, 5), permute_dims(Shape({3, 2}, 5), {1, 0}));
-  EXPECT_EQ(Shape({2, 3}, 5), permute_dims(Shape({3, 2}, 5), {1, 0}));
-  EXPECT_EQ(Shape({2}, 5), permute_dims(Shape({2}, 5), {0}));
-  EXPECT_EQ(Shape({3, 2, 4}, 5), permute_dims(Shape({2, 3, 4}, 5), {1, 0, 2}));
+  EXPECT_EQ(Shape({}, 2), permute_dims(Shape({}, 2), {}));
+  EXPECT_EQ(Shape({}, 2), permute_dims(Shape({}, 2), {0}));
+  EXPECT_EQ(Shape({2}, 3), permute_dims(Shape({2}, 3), {0}));
+  EXPECT_EQ(Shape({2, 3}, 2), permute_dims(Shape({2, 3}, 2), {0, 1}));
+  EXPECT_EQ(Shape({3, 2}, 3), permute_dims(Shape({2, 3}, 3), {1, 0}));
+  EXPECT_EQ(Shape({2, 3, 5}, 2), permute_dims(Shape({2, 3, 5}, 2), {0, 1, 2}));
+  EXPECT_EQ(Shape({5, 1, 3}, 3), permute_dims(Shape({3, 5}, 3), {1, 2, 0}));
+  EXPECT_EQ(Shape({5, 2, 3}, 2), permute_dims(Shape({2, 3, 5}, 2), {2, 0, 1}));
+  EXPECT_EQ(Shape({1, 3, 2}, 3), permute_dims(Shape({2, 3}, 3), {2, 1, 0}));
+  EXPECT_EQ(Shape({3, 2, 5}, 2), permute_dims(Shape({2, 3, 5}, 2), {1, 0, 2}));
+  EXPECT_EQ(Shape({1, 1, 1, 1, 3, 2, 7, 5}, 3), permute_dims(Shape({2, 3, 5, 7}, 3), {5, 4, 7, 6, 1, 0, 3, 2}));
+  EXPECT_EQ(Shape({2, 3, 5, 7, 3, 4, 8, 10}, 2), permute_dims(Shape({2, 3, 5, 7, 3, 4, 8, 10}, 2), {0, 1, 2, 3, 4, 5, 6, 7}));
+  EXPECT_EQ(Shape({4, 3, 10, 8, 3, 2, 7, 5}, 3), permute_dims(Shape({2, 3, 5, 7, 3, 4, 8, 10}, 3), {5, 4, 7, 6, 1, 0, 3, 2}));
 }
 
 TEST_F(ShapeOpsTest, CheckInvalidPermuteDims) {
-  EXPECT_THROW(permute_dims({1, 1, 2}, {1, 0}), Error);
-  EXPECT_THROW(permute_dims(Shape({1, 1, 2}, 5), {1, 0}), Error);
-  EXPECT_THROW(permute_dims({1, 2, 2}, {1, 0}), Error);
-  EXPECT_THROW(permute_dims(Shape({1, 2, 2}, 5), {1, 0}), Error);
-  EXPECT_THROW(permute_dims({2, 3, 4}, {1, 0}), Error);
-  EXPECT_THROW(permute_dims(Shape({2, 3, 4}, 5), {1, 0}), Error);
+  EXPECT_THROW(permute_dims(Shape({2}, 3), {}), Error);
+  EXPECT_THROW(permute_dims(Shape({2, 3}, 2), {0, 2}), Error);
+  EXPECT_THROW(permute_dims(Shape({2, 3}, 3), {0}), Error);
+  EXPECT_THROW(permute_dims(Shape({2, 3, 5}, 2), {4, 0, 1, 2}), Error);
+  EXPECT_THROW(permute_dims(Shape({2, 3, 5, 7, 3, 4, 8, 10}, 2), {0, 1, 2, 3, 4, 5, 6, 7, 8}), Error);
 }
 
 TEST_F(ShapeOpsTest, CheckMatMul) {

--- a/test/shape_ops_test.cc
+++ b/test/shape_ops_test.cc
@@ -303,6 +303,29 @@ TEST_F(ShapeOpsTest, CheckInvalidTranspose) {
   EXPECT_THROW(transpose(Shape({2, 3, 4}, 5)), Error);
 }
 
+TEST_F(ShapeOpsTest, CheckPermuteDims) {
+  EXPECT_EQ(Shape(), permute_dims({}, {1, 0}));
+  EXPECT_EQ(Shape({}, 5), permute_dims(Shape({}, 5), {1, 0}));
+  EXPECT_EQ(Shape({2}), permute_dims({1, 2}, {1, 0}));
+  EXPECT_EQ(Shape({2}, 5), permute_dims(Shape({1, 2}, 5), {1, 0}));
+  EXPECT_EQ(Shape({1, 2}), permute_dims({2}, {1, 0}));
+  EXPECT_EQ(Shape({1, 2}, 5), permute_dims(Shape({2}, 5), {1, 0}));
+  EXPECT_EQ(Shape({2, 3}), permute_dims({3, 2}, {1, 0}));
+  EXPECT_EQ(Shape({2, 3}, 5), permute_dims(Shape({3, 2}, 5), {1, 0}));
+  EXPECT_EQ(Shape({2, 3}, 5), permute_dims(Shape({3, 2}, 5), {1, 0}));
+  EXPECT_EQ(Shape({2}, 5), permute_dims(Shape({2}, 5), {0}));
+  EXPECT_EQ(Shape({3, 2, 4}, 5), permute_dims(Shape({2, 3, 4}, 5), {1, 0, 2}));
+}
+
+TEST_F(ShapeOpsTest, CheckInvalidPermuteDims) {
+  EXPECT_THROW(permute_dims({1, 1, 2}, {1, 0}), Error);
+  EXPECT_THROW(permute_dims(Shape({1, 1, 2}, 5), {1, 0}), Error);
+  EXPECT_THROW(permute_dims({1, 2, 2}, {1, 0}), Error);
+  EXPECT_THROW(permute_dims(Shape({1, 2, 2}, 5), {1, 0}), Error);
+  EXPECT_THROW(permute_dims({2, 3, 4}, {1, 0}), Error);
+  EXPECT_THROW(permute_dims(Shape({2, 3, 4}, 5), {1, 0}), Error);
+}
+
 TEST_F(ShapeOpsTest, CheckMatMul) {
   struct TestCase {
     vector<std::uint32_t> a, b, y;

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -1055,6 +1055,19 @@ TEST_F(TensorBackwardTest, CheckTransposeMN) {
   }
 }
 
+TEST_F(TensorBackwardTest, CheckPermuteDims111) {
+  const vector<float> gx_data {42, 43};
+  const vector<float> gy_data {42, 43};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({}, 2), 0);
+    const Tensor y = dev->permute_dims_fw(x, {0});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({}, 2), 0);
+    dev->permute_dims_bw(x, y, gy, {0}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
 TEST_F(TensorBackwardTest, CheckPermuteDimsN11) {
   const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
   const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -1009,6 +1009,168 @@ TEST_F(TensorBackwardTest, CheckTranspose) {
   }
 }
 
+TEST_F(TensorBackwardTest, CheckTranspose11) {
+  const vector<float> gx_data {42};
+  const vector<float> gy_data {42};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant({}, 0);
+    const Tensor y = dev->transpose_fw(x);
+    const Tensor gy = dev->new_tensor_by_vector({}, gy_data);
+    Tensor gx = dev->new_tensor_by_constant({}, 0);
+    dev->transpose_bw(x, y, gy, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckTransposeN1) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant({12}, 0);
+    const Tensor y = dev->transpose_fw(x);
+    const Tensor gy = dev->new_tensor_by_vector({1, 12}, gy_data);
+    Tensor gx = dev->new_tensor_by_constant({12}, 0);
+    dev->transpose_bw(x, y, gy, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckTranspose1N) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({1, 3}, 4), 0);
+    const Tensor y = dev->transpose_fw(x);
+    const Tensor gy = dev->new_tensor_by_vector(Shape({3}, 4), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({1, 3}, 4), 0);
+    dev->transpose_bw(x, y, gy, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckTransposeNN) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 3, 2, 4, 5, 7, 6, 8, 9, 11, 10, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({2, 2}, 3), 0);
+    const Tensor y = dev->transpose_fw(x);
+    const Tensor gy = dev->new_tensor_by_vector(Shape({2, 2}, 3), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({2, 2}, 3), 0);
+    dev->transpose_bw(x, y, gy, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckTransposeMN) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 3, 5, 2, 4, 6, 7, 9, 11, 8, 10, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({2, 3}, 2), 0);
+    const Tensor y = dev->transpose_fw(x);
+    const Tensor gy = dev->new_tensor_by_vector(Shape({3, 2}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({2, 3}, 2), 0);
+    dev->transpose_bw(x, y, gy, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDimsN11) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({6}, 2), 0);
+    const Tensor y = dev->permute_dims_fw(x, {1, 0});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({1, 6}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({6}, 2), 0);
+    dev->permute_dims_bw(x, y, gy, {1, 0}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDims1N1) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({1, 4}, 3), 0);
+    const Tensor y = dev->permute_dims_fw(x, {0, 2, 1});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({1, 1, 4}, 3), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({1, 4}, 3), 0);
+    dev->permute_dims_bw(x, y, gy, {0, 2, 1}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDims11N) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({1, 1, 4}, 3), 0);
+    const Tensor y = dev->permute_dims_fw(x, {2, 0, 1});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({4}, 3), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({1, 1, 4}, 3), 0);
+    dev->permute_dims_bw(x, y, gy, {2, 0, 1}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDimsMN1) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 3, 5, 2, 4, 6, 7, 9, 11, 8, 10, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({2, 3}, 2), 0);
+    const Tensor y = dev->permute_dims_fw(x, {1, 2, 0});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({3, 1, 2}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({2, 3}, 2), 0);
+    dev->permute_dims_bw(x, y, gy, {1, 2, 0}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDimsM1N) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({3, 1, 2}, 2), 0);
+    const Tensor y = dev->permute_dims_fw(x, {0, 2, 1});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({3, 2}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({3, 1, 2}, 2), 0);
+    dev->permute_dims_bw(x, y, gy, {0, 2, 1}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDims1MN) {
+  const vector<float> gx_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> gy_data {1, 4, 2, 5, 3, 6, 7, 10, 8, 11, 9, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({1, 3, 2}, 2), 0);
+    const Tensor y = dev->permute_dims_fw(x, {2, 0, 1});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({2, 1, 3}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({1, 3, 2}, 2), 0);
+    dev->permute_dims_bw(x, y, gy, {2, 0, 1}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
+TEST_F(TensorBackwardTest, CheckPermuteDimsLMN) {
+  const vector<float> gx_data {
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+  };
+  const vector<float> gy_data {
+    1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12,
+    13, 19, 14, 20, 15, 21, 16, 22, 17, 23, 18, 24,
+  };
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant(Shape({2, 3, 2}, 2), 0);
+    const Tensor y = dev->permute_dims_fw(x, {2, 0, 1});
+    const Tensor gy = dev->new_tensor_by_vector(Shape({2, 2, 3}, 2), gy_data);
+    Tensor gx = dev->new_tensor_by_constant(Shape({2, 3, 2}, 2), 0);
+    dev->permute_dims_bw(x, y, gy, {2, 0, 1}, gx);
+    EXPECT_TRUE(vector_match(gx_data, gx.to_vector()));
+  }
+}
+
 TEST_F(TensorBackwardTest, CheckAdd11) {
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_constant({2}, 0);

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -990,25 +990,6 @@ TEST_F(TensorBackwardTest, CheckMinMultipleLarge) {
   }
 }
 
-TEST_F(TensorBackwardTest, CheckTranspose) {
-  for (Device *dev : devices) {
-    const Tensor x = dev->new_tensor_by_constant(Shape({3, 4}, 2), 0);
-    const Tensor y = dev->transpose_fw(x);
-    const Tensor gy = dev->new_tensor_by_vector(
-        Shape({4, 3}, 2), {
-          0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
-          12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
-        });
-    Tensor gx = dev->new_tensor_by_constant(Shape({3, 4}, 2), 0);
-    dev->transpose_bw(x, y, gy, gx);
-    const vector<float> gx_val {
-      0, 4, 8, 1, 5, 9, 2, 6, 10, 3, 7, 11,
-      12, 16, 20, 13, 17, 21, 14, 18, 22, 15, 19, 23,
-    };
-    EXPECT_TRUE(vector_match(gx_val, gx.to_vector()));
-  }
-}
-
 TEST_F(TensorBackwardTest, CheckTranspose11) {
   const vector<float> gx_data {42};
   const vector<float> gy_data {42};

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -1589,6 +1589,100 @@ TEST_F(TensorForwardTest, CheckInvalidTranspose) {
   }
 }
 
+TEST_F(TensorForwardTest, CheckPermuteDimsN11) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({6}, 2), x_data);
+    const Tensor y = permute_dims(x, {1, 2, 0});
+    EXPECT_EQ(Shape({1, 1, 6}, 2), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckPermuteDims1N1) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({1, 4}, 3), x_data);
+    const Tensor y = permute_dims(x, {0, 2, 1});
+    EXPECT_EQ(Shape({1, 1, 4}, 3), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckPermuteDims11N) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({1, 1, 4}, 3), x_data);
+    const Tensor y = permute_dims(x, {2, 0, 1});
+    EXPECT_EQ(Shape({4}, 3), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckPermuteDimsMN1) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y_data {1, 3, 5, 2, 4, 6, 7, 9, 11, 8, 10, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({2, 3}, 2), x_data);
+    const Tensor y = permute_dims(x, {1, 2, 0});
+    EXPECT_EQ(Shape({3, 1, 2}, 2), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckPermuteDimsM1N) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({3, 1, 2}, 2), x_data);
+    const Tensor y = permute_dims(x, {0, 2, 1});
+    EXPECT_EQ(Shape({3, 2}, 2), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckPermuteDims1MN) {
+  const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+  const vector<float> y_data {1, 4, 2, 5, 3, 6, 7, 10, 8, 11, 9, 12};
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({1, 3, 2}, 2), x_data);
+    const Tensor y = permute_dims(x, {2, 0, 1});
+    EXPECT_EQ(Shape({2, 1, 3}, 2), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckPermuteDimsLMN) {
+  const vector<float> x_data {
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+    13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+  };
+  const vector<float> y_data {
+    1, 7, 2, 8, 3, 9, 4, 10, 5, 11, 6, 12,
+    13, 19, 14, 20, 15, 21, 16, 22, 17, 23, 18, 24,
+  };
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_vector(Shape({2, 3, 2}, 2), x_data);
+    const Tensor y = permute_dims(x, {2, 0, 1});
+    EXPECT_EQ(Shape({2, 2, 3}, 2), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
+TEST_F(TensorForwardTest, CheckInvalidPermuteDims) {
+  for (Device *dev : devices) {
+    const Tensor x = dev->new_tensor_by_constant({2, 3, 4}, 0);
+    EXPECT_THROW(permute_dims(x, {0, 1}), Error);
+    EXPECT_THROW(permute_dims(x, {0, 2}), Error);
+    EXPECT_THROW(permute_dims(x, {1, 0}), Error);
+    EXPECT_THROW(permute_dims(x, {0, 0, 1}), Error);
+    EXPECT_THROW(permute_dims(x, {0, 2, 0}), Error);
+  }
+}
+
 TEST_F(TensorForwardTest, CheckMatMulAA) {
   const vector<float> x_data {1, 2, 3, 4, 1, 0, 0, 1, 0, 2, 3, 0};
   const vector<float> y_data {7, 10, 15, 22, 1, 0, 0, 1, 6, 0, 0, 6};

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -1589,6 +1589,18 @@ TEST_F(TensorForwardTest, CheckInvalidTranspose) {
   }
 }
 
+TEST_F(TensorForwardTest, CheckPermuteDims111) {
+  const vector<float> x_data {42, 43};
+  const vector<float> y_data {42, 43};
+  for (Device *dev : devices) {
+    dev->dump_description();
+    const Tensor x = dev->new_tensor_by_vector(Shape({}, 2), x_data);
+    const Tensor y = permute_dims(x, {});
+    EXPECT_EQ(Shape({}, 2), y.shape());
+    EXPECT_TRUE(vector_match(y_data, y.to_vector()));
+  }
+}
+
 TEST_F(TensorForwardTest, CheckPermuteDimsN11) {
   const vector<float> x_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
   const vector<float> y_data {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};


### PR DESCRIPTION
This branch adds `perm` argument to `functions::transpose()`.
If `perm` is specified, it permutes the ordering of dimensions according to `perm`. Otherwise, it reverses the ordering of dimensions.