### PR TITLE
Move primitiv::Device::DeviceType to primitiv::DeviceType.

### DIFF
--- a/primitiv/core/device.h
+++ b/primitiv/core/device.h
@@ -12,6 +12,29 @@
 namespace primitiv {
 
 /**
+ * Device type.
+ */
+enum class DeviceType : std::uint32_t {
+  GROUP_FILTER = 0xffff0000,
+
+  GROUP_CPU = 0x00000000,
+
+  // NOTE(odashi):
+  // DeviceType::CPU is deprecated and will be deleted in the next release.
+  CPU = 0x00000000,
+
+  NAIVE = 0x00000000,
+  EIGEN = 0x00000001,
+
+  GROUP_CUDA = 0x00010000,
+  CUDA = 0x00010000,
+  CUDA16 = 0x00010001,
+
+  GROUP_OPENCL = 0x00020000,
+  OPENCL = 0x00020000,
+};
+
+/**
  * Interface of the Tensor provider.
  */
 class Device
@@ -20,29 +43,6 @@ class Device
   friend Tensor;
 
 public:
-  /**
-   * Device type.
-   */
-  enum class DeviceType : std::uint32_t {
-    GROUP_FILTER = 0xffff0000,
-
-    GROUP_CPU = 0x00000000,
-
-    // NOTE(odashi):
-    // DeviceType::CPU is deprecated and will be deleted in the next release.
-    CPU = 0x00000000,
-
-    NAIVE = 0x00000000,
-    EIGEN = 0x00000001,
-
-    GROUP_CUDA = 0x00010000,
-    CUDA = 0x00010000,
-    CUDA16 = 0x00010001,
-
-    GROUP_OPENCL = 0x00020000,
-    OPENCL = 0x00020000,
-  };
-
   Device() = default;
   virtual ~Device() = default;
 

--- a/primitiv/devices/cuda/device.h
+++ b/primitiv/devices/cuda/device.h
@@ -63,7 +63,7 @@ public:
   ~CUDA() override;
 
   void dump_description() const override;
-  Device::DeviceType type() const override { return Device::DeviceType::CUDA; }
+  DeviceType type() const override { return DeviceType::CUDA; }
 
 private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;

--- a/primitiv/devices/cuda/ops/copy_tensor.cu
+++ b/primitiv/devices/cuda/ops/copy_tensor.cu
@@ -9,10 +9,10 @@ namespace devices {
 
 void CUDA::copy_tensor_impl(const Tensor &x, Tensor &y) {
   switch (x.device().type()) {
-    case Device::DeviceType::NAIVE:
+    case DeviceType::NAIVE:
       reset_tensor_by_array(CDATA(x), y);
       break;
-    case Device::DeviceType::CUDA:
+    case DeviceType::CUDA:
       CUDA_CALL(::cudaSetDevice(dev_id_));
       // NOTE(odashi):
       // If source/destination devices use the unified memory space on the 64
@@ -22,7 +22,7 @@ void CUDA::copy_tensor_impl(const Tensor &x, Tensor &y) {
             sizeof(float) * x.shape().size(),
             cudaMemcpyDeviceToDevice, 0));
       break;
-    //case Device::DeviceType::CUDA16:
+    //case DeviceType::CUDA16:
       // TODO(odashi): Implement this section.
     default:
       reset_tensor_by_vector(x.to_vector(), y);

--- a/primitiv/devices/cuda16/device.h
+++ b/primitiv/devices/cuda16/device.h
@@ -63,9 +63,7 @@ public:
   ~CUDA16() override;
 
   void dump_description() const override;
-  Device::DeviceType type() const override {
-    return Device::DeviceType::CUDA16;
-  }
+  DeviceType type() const override { return DeviceType::CUDA16; }
 
 private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;

--- a/primitiv/devices/cuda16/ops/copy_tensor.cu
+++ b/primitiv/devices/cuda16/ops/copy_tensor.cu
@@ -9,12 +9,12 @@ namespace devices {
 
 void CUDA16::copy_tensor_impl(const Tensor &x, Tensor &y) {
   switch (x.device().type()) {
-    case Device::DeviceType::NAIVE:
+    case DeviceType::NAIVE:
       reset_tensor_by_array(CDATA(float, x), y);
       break;
-    //case Device::DeviceType::CUDA:
+    //case DeviceType::CUDA:
       // TODO(odashi): Implement this section.
-    case Device::DeviceType::CUDA16:
+    case DeviceType::CUDA16:
       CUDA_CALL(::cudaSetDevice(dev_id_));
       // NOTE(odashi):
       // If source/destination devices use the unified memory space on the 64

--- a/primitiv/devices/eigen/device.h
+++ b/primitiv/devices/eigen/device.h
@@ -26,7 +26,7 @@ public:
   ~Eigen() override = default;
 
   void dump_description() const override;
-  Device::DeviceType type() const override { return Device::DeviceType::EIGEN; }
+  DeviceType type() const override { return DeviceType::EIGEN; }
 
 private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;

--- a/primitiv/devices/eigen/ops/copy_tensor.cc
+++ b/primitiv/devices/eigen/ops/copy_tensor.cc
@@ -8,10 +8,10 @@ namespace devices {
 
 void Eigen::copy_tensor_impl(const Tensor &x, Tensor &y) {
   switch (x.device().type()) {
-    case Device::DeviceType::NAIVE:
+    case DeviceType::NAIVE:
       reset_tensor_by_array(CDATA(x), y);
       break;
-    case Device::DeviceType::EIGEN:
+    case DeviceType::EIGEN:
       reset_tensor_by_array(CDATA(x), y);
       break;
     default:

--- a/primitiv/devices/naive/device.h
+++ b/primitiv/devices/naive/device.h
@@ -26,7 +26,7 @@ public:
   ~Naive() override = default;
 
   void dump_description() const override;
-  Device::DeviceType type() const override { return Device::DeviceType::NAIVE; }
+  DeviceType type() const override { return DeviceType::NAIVE; }
 
 private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;

--- a/primitiv/devices/naive/ops/copy_tensor.cc
+++ b/primitiv/devices/naive/ops/copy_tensor.cc
@@ -8,7 +8,7 @@ namespace devices {
 
 void Naive::copy_tensor_impl(const Tensor &x, Tensor &y) {
   switch (x.device().type()) {
-    case Device::DeviceType::NAIVE:
+    case DeviceType::NAIVE:
       reset_tensor_by_array(CDATA(x), y);
       break;
     default:

--- a/primitiv/devices/opencl/device.cc
+++ b/primitiv/devices/opencl/device.cc
@@ -704,10 +704,10 @@ void OpenCL::reset_tensor_by_array_impl(const float values[], Tensor &x) {
 
 void OpenCL::copy_tensor_impl(const Tensor &x, Tensor &y) {
   switch (x.device().type()) {
-    case Device::DeviceType::NAIVE:
+    case DeviceType::NAIVE:
       reset_tensor_by_array(static_cast<const float *>(get_handle(x)), y);
       break;
-    case Device::DeviceType::OPENCL:
+    case DeviceType::OPENCL:
       if(&x.device() == this) {
         const std::uint32_t size = x.shape().size();
         state_->queue.enqueueCopyBuffer(

--- a/primitiv/devices/opencl/device.h
+++ b/primitiv/devices/opencl/device.h
@@ -71,7 +71,7 @@ public:
   ~OpenCL() override;
 
   void dump_description() const override;
-  Device::DeviceType type() const override { return Device::DeviceType::OPENCL; }
+  DeviceType type() const override { return DeviceType::OPENCL; }
 
 private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;

--- a/test/cuda16_device_test.cc
+++ b/test/cuda16_device_test.cc
@@ -40,7 +40,7 @@ protected:
 TEST_F(CUDA16DeviceTest, CheckDeviceType) {
   for (std::uint32_t dev_id : dev_ids) {
     devices::CUDA16 dev(dev_id);
-    EXPECT_EQ(Device::DeviceType::CUDA16, dev.type());
+    EXPECT_EQ(DeviceType::CUDA16, dev.type());
   }
 }
 

--- a/test/cuda_device_test.cc
+++ b/test/cuda_device_test.cc
@@ -38,7 +38,7 @@ protected:
 TEST_F(CUDADeviceTest, CheckDeviceType) {
   for (std::uint32_t dev_id : dev_ids) {
     devices::CUDA dev(dev_id);
-    EXPECT_EQ(Device::DeviceType::CUDA, dev.type());
+    EXPECT_EQ(DeviceType::CUDA, dev.type());
   }
 }
 

--- a/test/eigen_device_test.cc
+++ b/test/eigen_device_test.cc
@@ -23,7 +23,7 @@ class EigenDeviceTest : public testing::Test {};
 
 TEST_F(EigenDeviceTest, CheckDeviceType) {
   devices::Eigen dev;
-  EXPECT_EQ(Device::DeviceType::EIGEN, dev.type());
+  EXPECT_EQ(DeviceType::EIGEN, dev.type());
 }
 
 TEST_F(EigenDeviceTest, CheckNewDelete) {

--- a/test/naive_device_test.cc
+++ b/test/naive_device_test.cc
@@ -23,7 +23,7 @@ class NaiveDeviceTest : public testing::Test {};
 
 TEST_F(NaiveDeviceTest, CheckDeviceType) {
   devices::Naive dev;
-  EXPECT_EQ(Device::DeviceType::NAIVE, dev.type());
+  EXPECT_EQ(DeviceType::NAIVE, dev.type());
 }
 
 TEST_F(NaiveDeviceTest, CheckNewDelete) {

--- a/test/opencl_device_test.cc
+++ b/test/opencl_device_test.cc
@@ -46,7 +46,7 @@ protected:
 TEST_F(OpenCLDeviceTest, CheckDeviceType) {
   for (const Config &cfg : configs) {
     devices::OpenCL dev(cfg.pf_id, cfg.dev_id);
-    EXPECT_EQ(Device::DeviceType::OPENCL, dev.type());
+    EXPECT_EQ(DeviceType::OPENCL, dev.type());
   }
 }
 

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -445,7 +445,7 @@ TEST_F(TensorBackwardTest, CheckTanh) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 150000
+      = dev_type == DeviceType::CUDA16 ? 150000
       : 96;
     EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
   }
@@ -467,9 +467,9 @@ TEST_F(TensorBackwardTest, CheckSigmoid) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 32768
-      : dev_type == Device::DeviceType::EIGEN ? 6
-      : dev_type == Device::DeviceType::OPENCL ? 6
+      = dev_type == DeviceType::CUDA16 ? 32768
+      : dev_type == DeviceType::EIGEN ? 6
+      : dev_type == DeviceType::OPENCL ? 6
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
   }
@@ -491,8 +491,8 @@ TEST_F(TensorBackwardTest, CheckSoftplus) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::EIGEN ? 6
-      : dev_type == Device::DeviceType::OPENCL ? 6
+      = dev_type == DeviceType::EIGEN ? 6
+      : dev_type == DeviceType::OPENCL ? 6
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
   }
@@ -550,7 +550,7 @@ TEST_F(TensorBackwardTest, CheckTan) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
   }
@@ -670,7 +670,7 @@ TEST_F(TensorBackwardTest, CheckDivideConstL) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 8192
+        = dev_type == DeviceType::CUDA16 ? 8192
         : get_default_ulps(*dev);
       EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
     }
@@ -695,7 +695,7 @@ TEST_F(TensorBackwardTest, CheckPowConstR) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 8192
+        = dev_type == DeviceType::CUDA16 ? 8192
         : get_default_ulps(*dev);
       EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
     }
@@ -720,7 +720,7 @@ TEST_F(TensorBackwardTest, CheckPowConstL) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 8192
+        = dev_type == DeviceType::CUDA16 ? 8192
         : get_default_ulps(*dev);
       EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
     }
@@ -765,7 +765,7 @@ TEST_F(TensorBackwardTest, CheckELU) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 75000
+        = dev_type == DeviceType::CUDA16 ? 75000
         : 12;
       EXPECT_TRUE(vector_match_ulps(gx_val, gx.to_vector(), ulps));
     }
@@ -817,7 +817,7 @@ TEST_F(TensorBackwardTest, CheckMaxLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -851,7 +851,7 @@ TEST_F(TensorBackwardTest, CheckMaxMultipleLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -926,7 +926,7 @@ TEST_F(TensorBackwardTest, CheckMinLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -960,7 +960,7 @@ TEST_F(TensorBackwardTest, CheckMinMultipleLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -1404,7 +1404,7 @@ TEST_F(TensorBackwardTest, CheckDivide11) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1425,7 +1425,7 @@ TEST_F(TensorBackwardTest, CheckDivideNN) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1446,7 +1446,7 @@ TEST_F(TensorBackwardTest, CheckDivide1N) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1467,7 +1467,7 @@ TEST_F(TensorBackwardTest, CheckDivideN1) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1497,7 +1497,7 @@ TEST_F(TensorBackwardTest, CheckPow11) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1527,7 +1527,7 @@ TEST_F(TensorBackwardTest, CheckPowNN) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1558,7 +1558,7 @@ TEST_F(TensorBackwardTest, CheckPow1N) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -1589,7 +1589,7 @@ TEST_F(TensorBackwardTest, CheckPowN1) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(ga_val, ga.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(gb_val, gb.to_vector(), ulps));
@@ -2591,7 +2591,7 @@ TEST_F(TensorBackwardTest, CheckConv2D_VGG16FirstLayer) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 65536
+      = dev_type == DeviceType::CUDA16 ? 65536
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(gw_data, gw.to_vector(), ulps));
   } IGNORE_NOT_IMPLEMENTED

--- a/test/tensor_forward_test.cc
+++ b/test/tensor_forward_test.cc
@@ -898,7 +898,7 @@ TEST_F(TensorForwardTest, CheckSubtract) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
 
     {
@@ -960,7 +960,7 @@ TEST_F(TensorForwardTest, CheckMultiplyConst) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
 
     {
@@ -992,7 +992,7 @@ TEST_F(TensorForwardTest, CheckMultiplyScalar) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
 
     {
@@ -1025,7 +1025,7 @@ TEST_F(TensorForwardTest, CheckMultiplyScalarBatchBroadcast) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 8192
+        = dev_type == DeviceType::CUDA16 ? 8192
         : get_default_ulps(*dev);
 
       {
@@ -1056,7 +1056,7 @@ TEST_F(TensorForwardTest, CheckMultiplyScalarBatchBroadcast) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 8192
+        = dev_type == DeviceType::CUDA16 ? 8192
         : get_default_ulps(*dev);
 
       {
@@ -1089,7 +1089,7 @@ TEST_F(TensorForwardTest, CheckMultiply) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 16384
+      = dev_type == DeviceType::CUDA16 ? 16384
       : get_default_ulps(*dev);
 
     {
@@ -1153,7 +1153,7 @@ TEST_F(TensorForwardTest, CheckDivideConst) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
 
     {
@@ -1186,7 +1186,7 @@ TEST_F(TensorForwardTest, CheckDivideScalar) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 16384
+      = dev_type == DeviceType::CUDA16 ? 16384
       : get_default_ulps(*dev);
 
     {
@@ -1220,7 +1220,7 @@ TEST_F(TensorForwardTest, CheckDivideScalarBatchBroadcast) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 16384
+        = dev_type == DeviceType::CUDA16 ? 16384
         : get_default_ulps(*dev);
 
       {
@@ -1252,7 +1252,7 @@ TEST_F(TensorForwardTest, CheckDivideScalarBatchBroadcast) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 8192
+        = dev_type == DeviceType::CUDA16 ? 8192
         : get_default_ulps(*dev);
 
       {
@@ -1288,7 +1288,7 @@ TEST_F(TensorForwardTest, CheckDivide) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
 
     {
@@ -1837,7 +1837,7 @@ TEST_F(TensorForwardTest, CheckMatMulAB) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 16384
+      = dev_type == DeviceType::CUDA16 ? 16384
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(y_data, y.to_vector(), ulps));
   }
@@ -1897,7 +1897,7 @@ TEST_F(TensorForwardTest, CheckMatMulLarge) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 262144
+      = dev_type == DeviceType::CUDA16 ? 262144
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(y1_data, y1.to_vector(), ulps));
     EXPECT_TRUE(vector_match_ulps(y2_data, y2.to_vector(), ulps));
@@ -2136,13 +2136,13 @@ TEST_F(TensorForwardTest, CheckSigmoid) {
     const auto dev_type = dev->type();
 #ifdef PRIMITIV_MAYBE_FPMATH_X87
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::EIGEN ? 7
-      : dev_type == Device::DeviceType::OPENCL ? 6
+      = dev_type == DeviceType::EIGEN ? 7
+      : dev_type == DeviceType::OPENCL ? 6
       : get_default_ulps(*dev);
 #else
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::EIGEN ? 6
-      : dev_type == Device::DeviceType::OPENCL ? 6
+      = dev_type == DeviceType::EIGEN ? 6
+      : dev_type == DeviceType::OPENCL ? 6
       : get_default_ulps(*dev);
 #endif
     EXPECT_TRUE(vector_match_ulps(y_data, y.to_vector(), ulps));
@@ -2165,7 +2165,7 @@ TEST_F(TensorForwardTest, CheckSoftplus) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? get_default_ulps(*dev)
+      = dev_type == DeviceType::CUDA16 ? get_default_ulps(*dev)
       : 20;
     EXPECT_TRUE(vector_match_ulps(y_data, y.to_vector(), ulps));
   }
@@ -2337,7 +2337,7 @@ TEST_F(TensorForwardTest, CheckMaxLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -2388,7 +2388,7 @@ TEST_F(TensorForwardTest, CheckMinLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -2438,7 +2438,7 @@ TEST_F(TensorForwardTest, CheckSum2) {
   };
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(odashi):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -2497,7 +2497,7 @@ TEST_F(TensorForwardTest, CheckLogSumExp2) {
 
         const auto dev_type = dev->type();
         const std::uint32_t ulps
-          = dev_type == Device::DeviceType::CUDA16 ? get_default_ulps(*dev)
+          = dev_type == DeviceType::CUDA16 ? get_default_ulps(*dev)
           : 320;
         EXPECT_TRUE(vector_match_ulps(
               vector<float>(1, k + std::log(n)), y.to_vector(), ulps));
@@ -2533,7 +2533,7 @@ TEST_F(TensorForwardTest, CheckLogSoftmax) {
 
       const auto dev_type = dev->type();
       const float err
-        = dev_type == Device::DeviceType::CUDA16 ? 1e-2
+        = dev_type == DeviceType::CUDA16 ? 1e-2
         : 1e-6;
       EXPECT_TRUE(vector_near(y_data[i], y.to_vector(), err));
     }
@@ -2554,7 +2554,7 @@ TEST_F(TensorForwardTest, CheckLogSoftmax2) {
 
         const auto dev_type = dev->type();
         const float err
-          = dev_type == Device::DeviceType::CUDA16 ? 1e-2
+          = dev_type == DeviceType::CUDA16 ? 1e-2
           : 1e-3;
         EXPECT_TRUE(vector_near(
               vector<float>(n, -std::log(n)), y.to_vector(), err));
@@ -2590,7 +2590,7 @@ TEST_F(TensorForwardTest, CheckSoftmax) {
 
       const auto dev_type = dev->type();
       const float err
-        = dev_type == Device::DeviceType::CUDA16 ? 1e-2
+        = dev_type == DeviceType::CUDA16 ? 1e-2
         : 1e-6;
       EXPECT_TRUE(vector_near(y_data[i], y.to_vector(), err));
     }
@@ -2611,7 +2611,7 @@ TEST_F(TensorForwardTest, CheckSoftmax2) {
 
         const auto dev_type = dev->type();
         const float err
-          = dev_type == Device::DeviceType::CUDA16 ? 1e-3
+          = dev_type == DeviceType::CUDA16 ? 1e-3
           : 1e-6;
         EXPECT_TRUE(
             vector_near(vector<float>(n, 1./n), y.to_vector(), err));
@@ -2956,7 +2956,7 @@ TEST_F(TensorForwardTest, CheckSoftmaxCrossEntropy) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 16384
+        = dev_type == DeviceType::CUDA16 ? 16384
         : get_default_ulps(*dev);
       EXPECT_TRUE(vector_match_ulps(y_data[dim], y.to_vector(), ulps));
     }
@@ -2987,7 +2987,7 @@ TEST_F(TensorForwardTest, CheckSoftmaxCrossEntropyBatchBroadcast) {
 
       const auto dev_type = dev->type();
       const std::uint32_t ulps
-        = dev_type == Device::DeviceType::CUDA16 ? 16384
+        = dev_type == DeviceType::CUDA16 ? 16384
         : get_default_ulps(*dev);
       EXPECT_TRUE(vector_match_ulps(tc.y_data, y.to_vector(), ulps));
     }
@@ -3056,7 +3056,7 @@ TEST_F(TensorForwardTest, CheckSparseSoftmaxCrossEntropy) {
 
       const auto dev_type = dev->type();
       const float err
-        = dev_type == Device::DeviceType::CUDA16 ? 1e-2
+        = dev_type == DeviceType::CUDA16 ? 1e-2
         : 1e-6;
       EXPECT_TRUE(vector_near(tc.y_data, y.to_vector(), err));
     }
@@ -3310,7 +3310,7 @@ TEST_F(TensorForwardTest, CheckConv2D_5x5x1_5x5x1x1) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 32768
+      = dev_type == DeviceType::CUDA16 ? 32768
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(y_data, y.to_vector(), ulps));
   } IGNORE_NOT_IMPLEMENTED
@@ -3389,7 +3389,7 @@ TEST_F(TensorForwardTest, CheckConv2D_5x5x3_2x2x3x3) {
 
     const auto dev_type = dev->type();
     const std::uint32_t ulps
-      = dev_type == Device::DeviceType::CUDA16 ? 8192
+      = dev_type == DeviceType::CUDA16 ? 8192
       : get_default_ulps(*dev);
     EXPECT_TRUE(vector_match_ulps(y_data, y.to_vector(), ulps));
   } IGNORE_NOT_IMPLEMENTED

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -680,7 +680,7 @@ TEST_F(TensorTest, CheckArgMaxLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(odashi):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -707,7 +707,7 @@ TEST_F(TensorTest, CheckArgMaxMultipleLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -756,7 +756,7 @@ TEST_F(TensorTest, CheckArgMinLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(odashi):
         // Half-precision types have only (10+1) bits resolution.
         continue;
@@ -782,7 +782,7 @@ TEST_F(TensorTest, CheckArgMinMultipleLarge) {
 
   for (Device *dev : devices) {
     for (const std::uint32_t n : ns) {
-      if (n >= (1 << 11) && dev->type() == Device::DeviceType::CUDA16) {
+      if (n >= (1 << 11) && dev->type() == DeviceType::CUDA16) {
         // NOTE(vbkaisetsu):
         // Half-precision types have only (10+1) bits resolution.
         continue;

--- a/test/test_utils.cc
+++ b/test/test_utils.cc
@@ -41,7 +41,7 @@ namespace test_utils {
 
 std::uint32_t get_default_ulps(const primitiv::Device &dev) {
   switch (dev.type()) {
-    case primitiv::Device::DeviceType::CUDA16:
+    case primitiv::DeviceType::CUDA16:
       // NOTE(odashi):
       // Returns the half of the difference of the resolution between
       // float (23 bits) and half (10 bits).


### PR DESCRIPTION
To avoid redundancy in the class name.