### PR TITLE
Fix build errors

### DIFF
--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -35,7 +35,7 @@ docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
 docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 # script
-docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_C_API=ON -DPRIMITIV_BUILD_TESTS=ON -DEIGEN3_INCLUDE_DIR=/primitiv/eigen -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest/googletest"
+docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_C_API=ON -DPRIMITIV_BUILD_TESTS=ON -DEIGEN3_INCLUDE_DIR=/primitiv/eigen -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest"
 docker exec travis-ci bash -c "cd /primitiv && make VERBOSE=1"
 docker exec travis-ci bash -c "cd /primitiv && make test ARGS='-V'"
 docker exec travis-ci bash -c "cd /primitiv && make install"

--- a/.travis/osx.sh
+++ b/.travis/osx.sh
@@ -9,7 +9,7 @@ git clone https://github.com/google/googletest.git $TRAVIS_BUILD_DIR/googletest
 # script
 export CPLUS_INCLUDE_PATH=$CPLUS_INCLUDE_PATH::$TRAVIS_BUILD_DIR/googletest/googletest/include
 cd $TRAVIS_BUILD_DIR
-cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_BUILD_C_API=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=$TRAVIS_BUILD_DIR/googletest/googletest
+cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_BUILD_C_API=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=$TRAVIS_BUILD_DIR/googletest
 make VERBOSE=1
 make test ARGS='-V'
 make install

--- a/.travis/ubuntu.sh
+++ b/.travis/ubuntu.sh
@@ -23,7 +23,7 @@ docker exec travis-ci bash -c "cd ./pocl && cmake . -DCMAKE_INSTALL_PREFIX=/usr"
 docker exec travis-ci bash -c "cd ./pocl && make && make install"
 
 # script
-docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_C_API=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest/googletest"
+docker exec travis-ci bash -c "cd /primitiv && cmake . -DPRIMITIV_USE_EIGEN=ON -DPRIMITIV_USE_OPENCL=ON -DPRIMITIV_BUILD_C_API=ON -DPRIMITIV_BUILD_TESTS=ON -DPRIMITIV_GTEST_SOURCE_DIR=/usr/src/googletest"
 docker exec travis-ci bash -c "cd /primitiv && make VERBOSE=1"
 docker exec travis-ci bash -c "cd /primitiv && make test ARGS='-V'"
 docker exec travis-ci bash -c "cd /primitiv && make install"

--- a/primitiv/c/define.h
+++ b/primitiv/c/define.h
@@ -35,13 +35,13 @@ typedef uint32_t PRIMITIV_C_BOOL;
  * Only substituting `PRIMITIV_C_TRUE` to `PRIMITIV_C_BOOL` variables is
  * allowed.
  */
-#define PRIMITIV_C_FALSE 0
-#define PRIMITIV_C_TRUE 1
+#define PRIMITIV_C_FALSE 0u
+#define PRIMITIV_C_TRUE 1u
 
 /*
  * Return codes.
  */
-typedef uint32_t PRIMITIV_C_STATUS;
+typedef int32_t PRIMITIV_C_STATUS;
 #define PRIMITIV_C_OK 0
 #define PRIMITIV_C_ERROR -1
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,18 +15,16 @@ if(PRIMITIV_GTEST_SOURCE_DIR)
   ExternalProject_Add(
     GTest
     SOURCE_DIR ${PRIMITIV_GTEST_SOURCE_DIR}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND ""
     INSTALL_COMMAND ""
+    TEST_COMMAND ""
   )
-  ExternalProject_Get_Property(GTest binary_dir)
-  add_library(gtest STATIC IMPORTED)
-  set_property(
-    TARGET gtest
-    PROPERTY IMPORTED_LOCATION ${binary_dir}/libgtest.a
-  )
-  add_library(gtest_main STATIC IMPORTED)
-  set_property(
-    TARGET gtest_main
-    PROPERTY IMPORTED_LOCATION ${binary_dir}/libgtest_main.a
+  add_subdirectory(
+    ${PRIMITIV_GTEST_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+    EXCLUDE_FROM_ALL
   )
   set(GTEST_BOTH_LIBRARIES gtest gtest_main)
 else()
@@ -39,6 +37,7 @@ include_directories(
 )
 
 add_library(test_utils_OBJS OBJECT test_utils.h test_utils.cc)
+target_include_directories(test_utils_OBJS PUBLIC "${gtest_SOURCE_DIR}/include")
 
 function(primitiv_test name)
   add_executable(${name}_test

--- a/test/c/optimizer_test.cc
+++ b/test/c/optimizer_test.cc
@@ -155,7 +155,7 @@ TEST_F(COptimizerTest, CheckConfigs) {
   uint32_t uint_value = 0;
   EXPECT_EQ(PRIMITIV_C_OK, ::primitivGetOptimizerIntConfig(
       optimizer, "Optimizer.epoch", &uint_value));
-  EXPECT_EQ(2, uint_value);
+  EXPECT_EQ(2u, uint_value);
 
   uint_value = 0;
   EXPECT_EQ(PRIMITIV_C_OK, ::primitivGetOptimizerIntConfig(
@@ -167,7 +167,7 @@ TEST_F(COptimizerTest, CheckConfigs) {
   uint_value = 0;
   EXPECT_EQ(PRIMITIV_C_OK, ::primitivGetOptimizerIntConfig(
       optimizer, "Optimizer.epoch", &uint_value));
-  EXPECT_EQ(10, uint_value);
+  EXPECT_EQ(10u, uint_value);
 
   EXPECT_EQ(PRIMITIV_C_OK, ::primitivSetOptimizerIntConfig(
       optimizer, "foo", 50));
@@ -175,7 +175,7 @@ TEST_F(COptimizerTest, CheckConfigs) {
   uint_value = 1;
   EXPECT_EQ(PRIMITIV_C_OK, ::primitivGetOptimizerIntConfig(
       optimizer, "foo", &uint_value));
-  EXPECT_FLOAT_EQ(1, uint_value);
+  EXPECT_FLOAT_EQ(1u, uint_value);
 
   float float_value = 0.0;
   EXPECT_EQ(PRIMITIV_C_OK, ::primitivGetOptimizerFloatConfig(


### PR DESCRIPTION
This branch fixes the following errors:

* The latest googletest works with C++11, but it was built without `-std=c++11` on OSX
* signed/unsigned integer errors