### PR TITLE
Support g++ 4.8

### DIFF
--- a/primitiv/core/node_funcs.cc
+++ b/primitiv/core/node_funcs.cc
@@ -155,7 +155,7 @@ std::vector<Node> split(const Node &x, std::uint32_t dim, std::uint32_t n) {
 }
 
 template<>
-Node concat(const std::vector<Node> &xs, std::uint32_t dim) {
+Node concat<Node>(const std::vector<Node> &xs, std::uint32_t dim) {
   if (xs.empty()) PRIMITIV_THROW_ERROR("No nodes to concat.");
   return xs[0].graph().add_operator(
       std::unique_ptr<Operator>(new operators::Concat(dim)), xs
@@ -163,7 +163,7 @@ Node concat(const std::vector<Node> &xs, std::uint32_t dim) {
 }
 
 template<>
-Node concat(const std::vector<const Node *> &xs, std::uint32_t dim) {
+Node concat<Node>(const std::vector<const Node *> &xs, std::uint32_t dim) {
   return concat(::ptr_to_obj(xs), dim);
 }
 
@@ -362,7 +362,7 @@ std::vector<Node> split(const Node &x, std::uint32_t n) {
 }
 
 template<>
-Node concat(const std::vector<Node> &xs) {
+Node concat<Node>(const std::vector<Node> &xs) {
   if (xs.empty()) PRIMITIV_THROW_ERROR("No nodes to concat.");
   return xs[0].graph().add_operator(
       std::unique_ptr<Operator>(new operators::BatchConcat()), xs
@@ -370,7 +370,7 @@ Node concat(const std::vector<Node> &xs) {
 }
 
 template<>
-Node concat(const std::vector<const Node *> &xs) {
+Node concat<Node>(const std::vector<const Node *> &xs) {
   return concat(::ptr_to_obj(xs));
 }
 

--- a/primitiv/core/tensor_funcs.cc
+++ b/primitiv/core/tensor_funcs.cc
@@ -172,13 +172,13 @@ std::vector<Tensor> split(const Tensor &x, std::uint32_t dim, std::uint32_t n) {
 }
 
 template<>
-Tensor concat(const std::vector<const Tensor *> &xs, std::uint32_t dim) {
+Tensor concat<Tensor>(const std::vector<const Tensor *> &xs, std::uint32_t dim) {
   if (xs.empty()) PRIMITIV_THROW_ERROR("No tensors to be concatenated.");
   return xs[0]->device().concat_fw(xs, dim);
 }
 
 template<>
-Tensor concat(const std::vector<Tensor> &xs, std::uint32_t dim) {
+Tensor concat<Tensor>(const std::vector<Tensor> &xs, std::uint32_t dim) {
   return concat(::obj_to_ptr(xs), dim);
 }
 
@@ -384,13 +384,13 @@ std::vector<Tensor> split(const Tensor &x, std::uint32_t n) {
 }
 
 template<>
-Tensor concat(const std::vector<const Tensor *> &xs) {
+Tensor concat<Tensor>(const std::vector<const Tensor *> &xs) {
   if (xs.empty()) PRIMITIV_THROW_ERROR("No tensors to be concatenated.");
   return xs[0]->device().batch_concat_fw(xs);
 }
 
 template<>
-Tensor concat(const std::vector<Tensor> &xs) {
+Tensor concat<Tensor>(const std::vector<Tensor> &xs) {
   return concat(::obj_to_ptr(xs));
 }
 


### PR DESCRIPTION
Older g++ (such as 4.8) fails to build with "ambiguous template specialization" error.
This branch specifies template parameters explicitly to support older g++.