### PR TITLE
Fix compile error and multi-threading error

### DIFF
--- a/.travis/debian.sh
+++ b/.travis/debian.sh
@@ -6,6 +6,7 @@ docker pull debian:stable
 docker run --name travis-ci -v $TRAVIS_BUILD_DIR:/primitiv -td debian:stable /bin/bash
 
 # install
+docker exec travis-ci bash -c "echo 'deb http://deb.debian.org/debian stretch-backports main' >> /etc/apt/sources.list"
 docker exec travis-ci bash -c "apt update"
 docker exec travis-ci bash -c "apt install -y build-essential cmake googletest"
 
@@ -22,7 +23,8 @@ docker exec travis-ci bash -c "mkdir /primitiv/eigen"
 docker exec travis-ci bash -c "tar xf ./eigen.tar.bz2 -C /primitiv/eigen --strip-components 1"
 
 # install OpenCL environment
-docker exec travis-ci bash -c "apt install -y opencl-headers git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev clang-4.0 llvm-4.0-dev libclang-4.0-dev libz-dev"
+docker exec travis-ci bash -c "apt install -y opencl-headers git pkg-config libhwloc-dev libltdl-dev ocl-icd-dev ocl-icd-opencl-dev libz-dev"
+docker exec travis-ci bash -c "apt -t stretch-backports install -y clang-6.0 llvm-6.0-dev libclang-6.0-dev"
 docker exec travis-ci bash -c "wget https://github.com/CNugteren/CLBlast/archive/1.2.0.tar.gz -O ./clblast.tar.gz"
 docker exec travis-ci bash -c "mkdir ./clblast"
 docker exec travis-ci bash -c "tar xf ./clblast.tar.gz -C ./clblast --strip-components 1"

--- a/primitiv/core/spinlock.h
+++ b/primitiv/core/spinlock.h
@@ -51,18 +51,15 @@ public:
    */
   bool try_lock() {
     const std::thread::id this_thread_id = std::this_thread::get_id();
-    if (lock_count_ == 0) {
-      if (ready_.test_and_set(std::memory_order_acquire)) {
+    if (ready_.test_and_set(std::memory_order_acquire)) {
+      if (locked_thread_id_ != this_thread_id) {
         return false;
       }
+    } else {
       locked_thread_id_ = this_thread_id;
-      ++lock_count_;
-      return true;
-    } else if (locked_thread_id_ == this_thread_id) {
-      ++lock_count_;
-      return true;
     }
-    return false;
+    ++lock_count_;
+    return true;
   }
 
   /**

--- a/primitiv/devices/eigen/ops/common.h
+++ b/primitiv/devices/eigen/ops/common.h
@@ -10,7 +10,12 @@
 // For more ditails, see:
 // http://eigen.tuxfamily.org/index.php?title=Main_Page#License
 #define EIGEN_MPL2_ONLY
+#pragma GCC diagnostic push
+#if __GNUC__ >= 9
+#pragma GCC diagnostic ignored "-Wdeprecated-copy"
+#endif  //  __GNUC__ >= 9
 #include <Eigen/Eigen>
+#pragma GCC diagnostic pop
 
 template<typename T>
 using EMap = ::Eigen::Map<T>;


### PR DESCRIPTION
This branch fixes compile errors on Debian and Fedora, and fix a bug of `RecursiveSpinlock`.

The previous code checks `lock_count_` as a flag, but it is a normal variable and the value will not changed if the code is compiled by g++ 9 with the optimization.
The new code checks `ready_` instead.