### PR TITLE
default_obj_ of Device and Graph should be instantiated in one place.

### DIFF
--- a/primitiv/CMakeLists.txt
+++ b/primitiv/CMakeLists.txt
@@ -234,6 +234,8 @@ if(PRIMITIV_USE_OPENCL)
   )
 endif()
 
+add_definitions(-DPRIMITIV_BUILD_LIBRARY)
+
 # Builds the integrated binary.
 if(PRIMITIV_BUILD_STATIC_LIBRARY)
   add_library(primitiv STATIC ${primitiv_all_OBJS})

--- a/primitiv/core/graph.h
+++ b/primitiv/core/graph.h
@@ -243,7 +243,6 @@ private:
     std::vector<NodeInfo> rets;
   };
 
-  static Graph *default_obj_;
   std::vector<OperatorInfo> ops_;
 };
 

--- a/primitiv/core/mixins/default_settable.h
+++ b/primitiv/core/mixins/default_settable.h
@@ -64,8 +64,10 @@ public:
   }
 };
 
+#ifdef PRIMITIV_BUILD_LIBRARY
 template<typename T>
 T *DefaultSettable<T>::default_obj_ = nullptr;
+#endif
 
 }  // namespace mixins
 }  // namespace primitiv

--- a/test/mixins_test.cc
+++ b/test/mixins_test.cc
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#define PRIMITIV_BUILD_LIBRARY
 #include <primitiv/core/mixins/default_settable.h>
 #include <primitiv/core/mixins/identifiable.h>
 #include <primitiv/core/mixins/noncopyable.h>

--- a/test/mixins_test.cc
+++ b/test/mixins_test.cc
@@ -2,7 +2,10 @@
 
 #include <gtest/gtest.h>
 
-#define PRIMITIV_BUILD_LIBRARY
+#ifdef _WIN32
+# define PRIMITIV_BUILD_LIBRARY
+#endif
+
 #include <primitiv/core/mixins/default_settable.h>
 #include <primitiv/core/mixins/identifiable.h>
 #include <primitiv/core/mixins/noncopyable.h>

--- a/test/mixins_test.cc
+++ b/test/mixins_test.cc
@@ -2,9 +2,9 @@
 
 #include <gtest/gtest.h>
 
-#ifdef _WIN32
-# define PRIMITIV_BUILD_LIBRARY
-#endif
+// Require PRIMITIV_BUILD_LIBRARY
+// See https://github.com/primitiv/primitiv/pull/211
+#define PRIMITIV_BUILD_LIBRARY
 
 #include <primitiv/core/mixins/default_settable.h>
 #include <primitiv/core/mixins/identifiable.h>


### PR DESCRIPTION
Current implementation of primitiv defines `default_obj_` in header file device.h/graph.h.

This works almost cases. But when building DLL&EXE on Windows, `default_obj_` is instantiated in two places.

<del>
`default_obj_` in the DLL is set via set_default but `default_obj_` in the executable always NOT be updated. So the Windows application using primitiv always crash when constructor of Parameter/Input/Node is called. To fix this issue, an instantiation of `default_obj_` should be at a place. This change remove the definitions of `default_obj_`. And `Device::default_obj_` and `Graph::default_obj_` are instantiated via definition of dummy function. These instances are embedded in DLL, and code of application do not need to use any hacks(ex: define PRIMITIV_MAKE_INSTANCE in main.cc) to instantiate them.
</del>

I confirmed this works on Windows & Linux. Thanks.